### PR TITLE
Downgrade grunt to ^0.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "dateformat": "1.0.11",
-    "grunt": "1.0.1",
+    "grunt": "^0.4.5",
     "grunt-contrib-clean": "1.0.0",
     "grunt-contrib-concat": "1.0.1",
     "grunt-contrib-connect": "1.0.2",


### PR DESCRIPTION
This eliminates the peerDependencies complaints on `npm install` from the various grunt plugins being used.  I looked at upgrading the plugins but several still have no official support for grunt >= 1.0.0.
