### PR TITLE
Make code-dot-org/piskel npm-publishable

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+misc/
+node_modules/
+src/
+test/

--- a/README.md
+++ b/README.md
@@ -1,77 +1,17 @@
-Piskel
+Code Studio Piskel
 ======
 
-[![Travis Status](https://api.travis-ci.org/code-dot-org/piskel.png?branch=master)](https://travis-ci.org/code-dot-org/piskel) [![Built with Grunt](https://cdn.gruntjs.com/builtwith.png)](http://gruntjs.com/)
+[![Travis Status](https://api.travis-ci.org/code-dot-org/piskel.png?branch=master)](https://travis-ci.org/code-dot-org/piskel)
 
-A simple web-based tool for Spriting and Pixel art.
-
-![Piskel editor screenshot](https://screenletstore.appspot.com/img/8f03e768-ac59-11e3-b2a1-7f5a1b97c420.jpeg "Piskel editor screenshot")
-
-You can try the standalone editor at **http://juliandescottes.github.io/piskel** or see it integrated in **http://piskelapp.com**.
-
-Piskel is mainly developped by :
-
-* **[@juliandescottes](https://github.com/juliandescottes)**
-* **[@grosbouddha](https://github.com/grosbouddha)**
-
-## What's the point ?
-
-You can use Piskel to do two things :
-* **spriting** : create retro-style sprites for games
-
-![Megaman spritesheet](http://piskel-imgstore-a.appspot.com/img/c8081287-ac58-11e3-bd8c-b3c4036c0eee.png "Megaman spritesheet")
-
-* **pixelart** : create crazy/pretty pixelart animations for fun !
-
-![Rabbit jumping](http://piskel-imgstore-a.appspot.com/img/947f2dab-ac58-11e3-949a-b3c4036c0eee.gif "Rabit jumping")
-
-Integrated in **[piskelapp.com](http://piskelapp.com)**, you can share everything you work on with others as easily as you share a link.
-
-## Requirements
-
-Piskel supports the following browsers :
-* **Chrome** (latest)
-* **Firefox** (latest)
-* **Internet Explorer** 11+
-
-... and a fairly recent computer.
-
-We don't plan/want/could be forced into supporting older IEs. For Opera and Safari, we've never tested them but the gap shouldn't be huge.
-
-## Offline version
-
-Offline builds are available. More details in the [dedicated wiki page](https://github.com/juliandescottes/piskel/wiki/Desktop-applications).
-
-## Built with
-
-The Piskel editor is purely built in **JavaScript, HTML and CSS**. It uses Canvas extensively for displaying all them pretty sprites.
-
-We also use the following **libraries** :
-* [spectrum](https://github.com/bgrins/spectrum) : awesome standalone colorpicker
-* [gifjs](http://jnordberg.github.io/gif.js/) : generate animated GIFs in javascript, using webworkers
-* [supergif](https://github.com/buzzfeed/libgif-js) : modified version of SuperGif to parse and import GIFs
-* [jszip](https://github.com/Stuk/jszip) : create, read and edit .zip files with Javascript
-* [canvas-toBlob](https://github.com/eligrey/canvas-toBlob.js/) : shim for canvas toBlob
-* [jquery](http://jquery.com/) : used sporadically in the application
-* [bootstrap-tooltip](http://getbootstrap.com/javascript/#tooltips) : nice tooltips
-
-As well as some **icons** from the [Noun Project](http://thenounproject.com/) :
-* Folder by Simple Icons from The Noun Project
-* (and probably one or two others)
-
-
-## Contributing ?
-
-Help is always welcome !
-
-* **Issues** : Found a problem when using the application, want to request a feature, [open an issue](https://github.com/juliandescottes/piskel/issues).
-* **Participate** : Have a look at the [wiki](https://github.com/juliandescottes/piskel/wiki) to set up the development environment
+This is a custom version of the excellent [Piskel Editor](https://github.com/juliandescottes/piskel) by [@juliandescottes](https://github.com/juliandescottes) and [@grosbouddha](https://github.com/grosbouddha), designed for embedded use with the Code.org Code Studio learning platform.  For more information on using or developing Piskel, please see [the main repository](https://github.com/juliandescottes/piskel).
 
 ## License
 
-Copyright 2016 Julian Descottes
+Code Studio Piskel is Copyright 2016 Code.org
 
-Licensed under the Apache License, Version 2.0 (the "License");
+Piskel is Copyright 2016 Julian Descottes
+
+Both are licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
@@ -82,8 +22,3 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-## Mobile/Tablets
-
-There is no support for mobile for now.
-

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Code Studio Piskel
 
 This is a custom version of the excellent [Piskel Editor](https://github.com/juliandescottes/piskel) by [@juliandescottes](https://github.com/juliandescottes) and [@grosbouddha](https://github.com/grosbouddha), designed for embedded use with the Code.org Code Studio learning platform.  For more information on using or developing Piskel, please see [the main repository](https://github.com/juliandescottes/piskel).
 
+## Local Development Setup
+
+Note: To run local integration tests you should install CasperJS 1.0.2 (not included as a dependency in this repo) and make sure it has access to PhantomJS 1.9.2 (downloaded to node_modules/.bin on `npm install` but not necessarily in your PATH).
+
 ## License
 
 Code Studio Piskel is Copyright 2016 Code.org

--- a/package.json
+++ b/package.json
@@ -1,17 +1,27 @@
 {
-  "author": "Julian Descottes, Vincent Renaudin",
-  "name": "piskel",
-  "main": "./dest/prod/index.html",
-  "description": "Web based 2d animations editor",
-  "version": "0.7.0-SNAPSHOT",
-  "homepage": "http://github.com/juliandescottes/piskel",
+  "name": "@code-dot-org/piskel",
+  "version": "0.0.1",
+  "description": "Code.org fork of juliandescottes/piskel for use within the Code Studio learning environment.",
+  "author": "Julian Descottes",
+  "contributors": [
+    "Vincent Renaudin",
+    "Brad Buchanan <brad@code.org>"
+  ],
+  "license" : "Apache-2.0",
+  "homepage": "http://github.com/code-dot-org/piskel",
   "repository": {
     "type": "git",
-    "url": "http://github.com/juliandescottes/piskel.git"
+    "url": "http://github.com/code-dot-org/piskel.git"
   },
+  "files": [
+    "dest/prod"
+  ],
+  "main": "./dest/prod/index.html",
   "scripts": {
     "test": "grunt test",
-    "start": "nodewebkit"
+    "start": "nodewebkit",
+    "preversion": "grunt test-local build",
+    "postversion": "git push && git push --tags && npm publish"
   },
   "devDependencies": {
     "dateformat": "1.0.11",

--- a/test/casperjs/SmokeTest.js
+++ b/test/casperjs/SmokeTest.js
@@ -1,7 +1,7 @@
 casper
   .start(casper.cli.get('baseUrl')+"?debug")
   .then(function () {
-    this.wait(casper.cli.get('delay'));
+    this.wait(10000);
   })
   .then(function () {
     this.echo(casper.cli.get('baseUrl')+"?debug");


### PR DESCRIPTION
This PR prepares our fork of Piskel to be published as the npm package [`@code-dot-org/piskel`](https://www.npmjs.com/package/@code-dot-org/piskel).  We won't be publishing globally as [`piskel`](https://www.npmjs.com/package/piskel) - that name should be reserved for @juliandescottes to use, should he choose to do so, and we wouldn't want our fork (which is very specific to our purposes) to be confused with the original version.

To that end I've done the following:
- Overhauled the README to describe the custom purpose of this fork and point people back to https://github.com/juliandescottes/piskel
- Overhauled package.json with new metadata and publishing settings
  - Change package name to `@code-dot-org/piskel`
  - Make sure description and URLs reference our own repo
  - Reset version to `0.0.1` (to be updated soon after we publish)
  - Whitelist `dest/prod` files for inclusion in the published package - we want to publish ready-to-use build output, not source.
  - Add a `preversion` hook that runs the full local test suite and then does a production build.
  - Add a `postversion` hook that pushes the new version commit/tag to github and publishes the new version to npm.
- Added .npmignore to prevent npm from using .gitignore, which would exclude the built files we want to publish.
- Made a small adjustment to the integration tests to get them passing locally.

The end result is that we will keep **only the source code in GitHub** like we want, with tags that correspond to **published built-files packages on npm**.

If you want another example of this pattern, see my tiny proof-of-concept project on [GitHub](https://github.com/islemaster/transpiled-published-static-application-demo) and [npm](https://www.npmjs.com/package/transpiled-published-static-application-demo).
