### PR TITLE
Improve PiskelApi

### DIFF
--- a/src/js/PiskelApi.js
+++ b/src/js/PiskelApi.js
@@ -16,7 +16,7 @@ var PiskelApi = (function (module) {
    *   piskelApi.loadSpritesheet(myImage, 256, 128);
    * @constructor
    */
-  function PiskelApi(iframe) {
+  function PiskelApi() {
     /** @private {iframe} */
     this.iframe_ = null;
 
@@ -47,6 +47,10 @@ var PiskelApi = (function (module) {
 
   /** @enum {string} Message type constants for Piskel internal use. */
   PiskelApi.MessageType = {
+    // Piskel is initialized and ready for API commmands.
+    // Arguments: none
+    PISKEL_API_READY: 'PISKEL_API_READY',
+
     // Load a spritesheet for editing
     // Arguments: uri, frameSizeX, frameSizeY
     LOAD_SPRITESHEET: 'LOAD_SPRITESHEET',
@@ -96,9 +100,18 @@ var PiskelApi = (function (module) {
   };
 
   /**
+   * Register a callback that will be called when Piskel is initialized and ready
+   * for API messages.
+   * @param {function} callback
+   */
+  PiskelApi.prototype.onPiskelReady = function (callback) {
+    this.addCallback_(PiskelApi.MessageType.PISKEL_API_READY, callback);
+  };
+
+  /**
    * Register a callback that will be called whenever Piskel issues a
    * save event.
-   * @param callback
+   * @param {function} callback
    */
   PiskelApi.prototype.onStateSaved = function (callback) {
     this.addCallback_(PiskelApi.MessageType.STATE_SAVED, callback);

--- a/src/js/PiskelApi.js
+++ b/src/js/PiskelApi.js
@@ -50,15 +50,16 @@ var PiskelApi = (function (module) {
    *        pixels.
    * @param {number} frameSizeY - Height of a frame within the spritesheet, in
    *        pixels.
+   * @param {number} [frameRate] - Animation rate in frames per second.
    * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/data_URIs
    */
-  PiskelApi.prototype.loadSpritesheet = function (uri, frameSizeX, frameSizeY) {
-    // TODO: Do we need to store the key here too, or can something else manage that?
+  PiskelApi.prototype.loadSpritesheet = function (uri, frameSizeX, frameSizeY, frameRate) {
     this.sendMessage_({
       type: PiskelApi.MessageType.LOAD_SPRITESHEET,
       uri: uri,
       frameSizeX: frameSizeX,
-      frameSizeY: frameSizeY
+      frameSizeY: frameSizeY,
+      frameRate: frameRate
     });
   };
 

--- a/src/js/service/ImportService.js
+++ b/src/js/service/ImportService.js
@@ -35,7 +35,15 @@
     var frameOffsetX = options.frameOffsetX;
     var frameOffsetY = options.frameOffsetY;
     var smoothing = options.smoothing;
-    var frameRate = options.frameRate;
+    var frameRate = typeof options.frameRate !== 'undefined' ?
+        options.frameRate : Constants.DEFAULT.FPS;
+
+    var setPiskelFromFrameImages = function (frameImages) {
+      var piskel = this.createPiskelFromImages_(frameImages, frameSizeX,
+          frameSizeY, smoothing);
+      this.piskelController_.setPiskel(piskel);
+      this.previewController_.setFPS(frameRate);
+    }.bind(this);
 
     var gifLoader = new window.SuperGif({
       gif: image
@@ -49,22 +57,22 @@
 
         if (importType === 'single' || images.length > 1) {
           // Single image import or animated gif
-          this.createPiskelFromImages_(images, frameSizeX, frameSizeY, smoothing, frameRate);
+          setPiskelFromFrameImages(images);
         } else {
           // Spritesheet
-          var frameImages = this.createImagesFromSheet_(images[0]);
-          this.createPiskelFromImages_(frameImages, frameSizeX, frameSizeY, smoothing, frameRate);
+          var frameImages = this.createImagesFromSheet_(images[0], frameSizeX, frameSizeY, frameOffsetX, frameOffsetY);
+          setPiskelFromFrameImages(frameImages);
         }
         onComplete();
       }.bind(this),
       error: function () {
         if (importType === 'single') {
           // Single image
-          this.createPiskelFromImages_([image], frameSizeX, frameSizeY, smoothing, frameRate);
+          setPiskelFromFrameImages([image]);
         } else {
           // Spritesheet
           var frameImages = this.createImagesFromSheet_(image, frameSizeX, frameSizeY, frameOffsetX, frameOffsetY);
-          this.createPiskelFromImages_(frameImages, frameSizeX, frameSizeY, smoothing, frameRate);
+          setPiskelFromFrameImages(frameImages);
         }
         onComplete();
       }.bind(this)
@@ -97,21 +105,15 @@
    * @param {!number} frameSizeX
    * @param {!number} frameSizeY
    * @param {!boolean} smoothing
-   * @param {number} [frameRate]
+   * @return {pskl.model.Piskel}
    * @private
    */
   ns.ImportService.prototype.createPiskelFromImages_ = function (images,
-      frameSizeX, frameSizeY, smoothing, frameRate) {
-    if (typeof frameRate !== 'number' || isNaN(frameRate)) {
-      frameRate = Constants.DEFAULT.FPS;
-    }
+      frameSizeX, frameSizeY, smoothing) {
     var frames = this.createFramesFromImages_(images, frameSizeX, frameSizeY, smoothing);
     var layer = pskl.model.Layer.fromFrames('Layer 1', frames);
     var descriptor = new pskl.model.piskel.Descriptor('Imported piskel', '');
-    var piskel = pskl.model.Piskel.fromLayers([layer], descriptor);
-
-    this.piskelController_.setPiskel(piskel);
-    this.previewController_.setFPS(frameRate);
+    return pskl.model.Piskel.fromLayers([layer], descriptor);
   };
 
   /**

--- a/src/js/service/ImportService.js
+++ b/src/js/service/ImportService.js
@@ -24,6 +24,7 @@
    * @param {number} [options.frameOffsetX] only used in spritesheet imports.
    * @param {number} [options.frameOffsetY] only used in spritesheet imports.
    * @param {!boolean} options.smoothing
+   * @param {number} [options.frameRate] in frames per second
    * @param {function} [onComplete]
    */
   ns.ImportService.prototype.newPiskelFromImage = function (image, options, onComplete) {
@@ -34,6 +35,7 @@
     var frameOffsetX = options.frameOffsetX;
     var frameOffsetY = options.frameOffsetY;
     var smoothing = options.smoothing;
+    var frameRate = options.frameRate;
 
     var gifLoader = new window.SuperGif({
       gif: image
@@ -47,22 +49,22 @@
 
         if (importType === 'single' || images.length > 1) {
           // Single image import or animated gif
-          this.createPiskelFromImages_(images, frameSizeX, frameSizeY, smoothing);
+          this.createPiskelFromImages_(images, frameSizeX, frameSizeY, smoothing, frameRate);
         } else {
           // Spritesheet
           var frameImages = this.createImagesFromSheet_(images[0]);
-          this.createPiskelFromImages_(frameImages, frameSizeX, frameSizeY, smoothing);
+          this.createPiskelFromImages_(frameImages, frameSizeX, frameSizeY, smoothing, frameRate);
         }
         onComplete();
       }.bind(this),
       error: function () {
         if (importType === 'single') {
           // Single image
-          this.createPiskelFromImages_([image], frameSizeX, frameSizeY, smoothing);
+          this.createPiskelFromImages_([image], frameSizeX, frameSizeY, smoothing, frameRate);
         } else {
           // Spritesheet
           var frameImages = this.createImagesFromSheet_(image, frameSizeX, frameSizeY, frameOffsetX, frameOffsetY);
-          this.createPiskelFromImages_(frameImages, frameSizeX, frameSizeY, smoothing);
+          this.createPiskelFromImages_(frameImages, frameSizeX, frameSizeY, smoothing, frameRate);
         }
         onComplete();
       }.bind(this)
@@ -95,17 +97,21 @@
    * @param {!number} frameSizeX
    * @param {!number} frameSizeY
    * @param {!boolean} smoothing
+   * @param {number} [frameRate]
    * @private
    */
   ns.ImportService.prototype.createPiskelFromImages_ = function (images,
-      frameSizeX, frameSizeY, smoothing) {
+      frameSizeX, frameSizeY, smoothing, frameRate) {
+    if (typeof frameRate !== 'number' || isNaN(frameRate)) {
+      frameRate = Constants.DEFAULT.FPS;
+    }
     var frames = this.createFramesFromImages_(images, frameSizeX, frameSizeY, smoothing);
     var layer = pskl.model.Layer.fromFrames('Layer 1', frames);
     var descriptor = new pskl.model.piskel.Descriptor('Imported piskel', '');
     var piskel = pskl.model.Piskel.fromLayers([layer], descriptor);
 
     this.piskelController_.setPiskel(piskel);
-    this.previewController_.setFPS(Constants.DEFAULT.FPS);
+    this.previewController_.setFPS(frameRate);
   };
 
   /**

--- a/src/js/service/PiskelApiService.js
+++ b/src/js/service/PiskelApiService.js
@@ -59,6 +59,9 @@
     $.subscribe(Events.PISKEL_SAVE_STATE, this.onSaveStateEvent.bind(this));
     $.subscribe(Events.FPS_CHANGED, this.onSaveStateEvent.bind(this));
 
+    // Notify any attached API that piskel is ready to use.
+    this.sendMessage_({type: MessageType.PISKEL_API_READY});
+
     this.log('Initialized.');
   };
 

--- a/src/js/service/PiskelApiService.js
+++ b/src/js/service/PiskelApiService.js
@@ -116,7 +116,7 @@
     var image = new Image();
     image.onload = function () {
       // Avoid retriggering image onload (something about JsGif?)
-      image.onload = function () {};
+      image.onload = Constants.EMPTY_FUNCTION;
       this.importService_.newPiskelFromImage(image, {
         importType: 'spritesheet',
         frameSizeX: frameSizeX,
@@ -127,7 +127,8 @@
         frameRate: frameRate
       }, function () {
         this.log('Image loaded.');
-        // TODO: Report load complete out to parent app?
+        // Report async load completed.
+        this.sendMessage_({type: MessageType.SPRITESHEET_LOADED});
       }.bind(this));
     }.bind(this);
     image.src = uri;

--- a/src/js/service/PiskelApiService.js
+++ b/src/js/service/PiskelApiService.js
@@ -57,6 +57,7 @@
     // For implementing auto-save: On a save state event, we should notify
     // the parent app that the animation has changed.
     $.subscribe(Events.PISKEL_SAVE_STATE, this.onSaveStateEvent.bind(this));
+    $.subscribe(Events.FPS_CHANGED, this.onSaveStateEvent.bind(this));
 
     this.log('Initialized.');
   };
@@ -99,11 +100,19 @@
 
     // Delegate according to message type
     if (message.type === MessageType.LOAD_SPRITESHEET) {
-      this.loadSpritesheet(message.uri, message.frameSizeX, message.frameSizeY);
+      this.loadSpritesheet(message.uri, message.frameSizeX, message.frameSizeY,
+          message.frameRate);
     }
   };
 
-  ns.PiskelApiService.prototype.loadSpritesheet = function (uri, frameSizeX, frameSizeY) {
+  /**
+   * @param {!string} uri
+   * @param {!number} frameSizeX
+   * @param {!number} frameSizeY
+   * @param {number} [frameRate]
+   */
+  ns.PiskelApiService.prototype.loadSpritesheet = function (uri, frameSizeX,
+      frameSizeY, frameRate) {
     var image = new Image();
     image.onload = function () {
       // Avoid retriggering image onload (something about JsGif?)
@@ -114,7 +123,8 @@
         frameSizeY: frameSizeY,
         frameOffsetX: 0,
         frameOffsetY: 0,
-        smoothing: false
+        smoothing: false,
+        frameRate: frameRate
       }, function () {
         this.log('Image loaded.');
         // TODO: Report load complete out to parent app?
@@ -138,7 +148,8 @@
         sourceSizeY: outputCanvas.height,
         frameSizeX: this.piskelController_.getWidth(),
         frameSizeY: this.piskelController_.getHeight(),
-        frameCount: this.piskelController_.getFrameCount()
+        frameCount: this.piskelController_.getFrameCount(),
+        frameRate: this.piskelController_.getFPS()
       });
     }.bind(this));
   };


### PR DESCRIPTION
New features:
- We can pass a framerate to `loadSpritesheet`, and pass the current framerate back on a save event.
- `loadSpritesheet` now accepts a callback, so that the client application can be notified when the load is complete.
- API initialization has changed; you now use the `attachToPiskel` and `detachFromPiskel` methods, which allows for clean teardown of the API, important on a page (like Gamelab) where Piskel might be destroyed and recreated.
- The API now lets you hook up an `onPiskelReady` callback, to notify you that it's ready to receive API commands.
