### PR TITLE
Disable alert that piskel changes aren't saved

### DIFF
--- a/src/js/service/BeforeUnloadService.js
+++ b/src/js/service/BeforeUnloadService.js
@@ -11,12 +11,13 @@
 
   ns.BeforeUnloadService.prototype.onBeforeUnload = function (evt) {
     pskl.app.backupService.backup();
-    if (pskl.app.savedStatusService.isDirty()) {
+    // Code.org - disable alert because Gamelab saves the animations automatically.
+    /*if (pskl.app.savedStatusService.isDirty()) {
       var confirmationMessage = 'Your Piskel seems to have unsaved changes';
 
       (evt || window.event).returnValue = confirmationMessage;
       return confirmationMessage;
-    }
+    }*/
   };
 
 })();


### PR DESCRIPTION
The animation tab in gamelab saves animations automatically so we don't need to show an alert for the animation not being saved. There are some areas in our fork where we've added a comment and disabled features by commenting them out. I can also potentially make this a flag, but I'm not sure that is worth is for this one isolated change. I can also go back and make this a flag later if Brad thinks it'd be a good idea.

For now, this was one of my to-dos and it will fix the test. 
Test that broke - https://github.com/code-dot-org/code-dot-org/pull/10715
