### PR TITLE
Add functions to the Piskel API to hide and show the frame column

### DIFF
--- a/src/js/PiskelApi.js
+++ b/src/js/PiskelApi.js
@@ -129,6 +129,20 @@ var PiskelApi = (function (module) {
   };
 
   /**
+   * Hides the frame column in Piskel UI.
+   */
+  PiskelApi.prototype.hideFrameColumn = function() {
+    document.getElementById('preview-list-wrapper').style.display = 'none';
+  };
+
+  /**
+   * Shows the frame column in Piskel UI.
+   */
+  PiskelApi.prototype.showFrameColumn = function() {
+    document.getElementById('preview-list-wrapper').style.display = 'unset';
+  };
+
+  /**
    * Register a callback that will be called when Piskel is initialized and ready
    * for API messages.
    * @param {function} callback


### PR DESCRIPTION
Some how piskel got unlinked from my locally dev environment and struggling to get it working again to test with code-dot-org, but I did test to make sure these lines work in piskel so I have no reason to believe they won't work in code-dot-org
