### PR TITLE
Piskel api change to toggle the frame column

### DIFF
--- a/src/js/PiskelApi.js
+++ b/src/js/PiskelApi.js
@@ -65,7 +65,11 @@ var PiskelApi = (function (module) {
 
     // The animation changed, and Piskel has internally saved its state.
     // Arguments: ???
-    STATE_SAVED: 'STATE_SAVED'
+    STATE_SAVED: 'STATE_SAVED',
+
+    // Hide or show the frame column.
+    // Arguments: hideFrameColumn
+    TOGGLE_FRAME_COLUMN: 'TOGGLE_FRAME_COLUMN',
   };
 
   /**
@@ -129,17 +133,14 @@ var PiskelApi = (function (module) {
   };
 
   /**
-   * Hides the frame column in Piskel UI.
+   * Hides and shows the frame column in Piskel UI.
+   * @param {boolean} hideFrameColumn
    */
-  PiskelApi.prototype.hideFrameColumn = function() {
-    document.getElementById('preview-list-wrapper').style.display = 'none';
-  };
-
-  /**
-   * Shows the frame column in Piskel UI.
-   */
-  PiskelApi.prototype.showFrameColumn = function() {
-    document.getElementById('preview-list-wrapper').style.display = 'unset';
+  PiskelApi.prototype.toggleFrameColumn = function(hideFrameColumn) {
+    this.sendMessage_({
+      type: PiskelApi.MessageType.TOGGLE_FRAME_COLUMN,
+      hideFrameColumn: hideFrameColumn
+    });
   };
 
   /**

--- a/src/js/service/PiskelApiService.js
+++ b/src/js/service/PiskelApiService.js
@@ -115,6 +115,8 @@
     } else if (message.type === MessageType.LOAD_SPRITESHEET) {
       this.loadSpritesheet(message.uri, message.frameSizeX, message.frameSizeY,
           message.frameRate);
+    } else if (message.type === MessageType.TOGGLE_FRAME_COLUMN) {
+      this.toggleFrameColumn(message.hideFrameColumn);
     }
   };
 
@@ -168,6 +170,17 @@
       }.bind(this));
     }.bind(this);
     image.src = uri;
+  };
+
+  /**
+   * @param {boolean} hideFrameColumn
+   */
+  ns.PiskelApiService.prototype.toggleFrameColumn = function(hideFrameColumn) {
+    if (hideFrameColumn) {
+      document.getElementById('preview-list-wrapper').style.display = 'none';
+    } else {
+      document.getElementById('preview-list-wrapper').style.display = 'unset';
+    }
   };
 
   ns.PiskelApiService.prototype.onSaveStateEvent = function (evt, action) {


### PR DESCRIPTION
Uses the PiskelApiService so messages actually get sent with this implementation. Tested locally with Gamelab.
