### PR TITLE
Clear history stack on loading new animations

### DIFF
--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -45,6 +45,8 @@ var Events = {
 
   PEN_SIZE_CHANGED : 'PEN_SIZE_CHANGED',
 
+  LOAD_NEW_PISKEL: 'LOAD_NEW_PISKEL',
+
   /**
    * Fired when a Piskel is successfully saved
    */

--- a/src/js/service/HistoryService.js
+++ b/src/js/service/HistoryService.js
@@ -25,6 +25,7 @@
 
   ns.HistoryService.prototype.init = function () {
     $.subscribe(Events.PISKEL_SAVE_STATE, this.onSaveStateEvent.bind(this));
+    $.subscribe(Events.LOAD_NEW_PISKEL, this.clearState.bind(this));
 
     var shortcuts = pskl.service.keyboard.Shortcuts;
     this.shortcutService.registerShortcut(shortcuts.MISC.UNDO, this.undo.bind(this));
@@ -177,6 +178,12 @@
     var layer = this.piskelController.getLayerAt(state.layerIndex);
     var frame = layer.getFrameAt(state.frameIndex);
     action.scope.replay(frame, action.replay);
+  };
+
+  ns.HistoryService.prototype.clearState = function() {
+    this.stateQueue = [];
+    this.currentIndex = -1;
+    this.lastLoadState = -1;
   };
 
 })();

--- a/src/js/service/PiskelApiService.js
+++ b/src/js/service/PiskelApiService.js
@@ -66,6 +66,8 @@
     // the parent app that the animation has changed.
     $.subscribe(Events.PISKEL_SAVE_STATE, this.onSaveStateEvent.bind(this));
     $.subscribe(Events.FPS_CHANGED, this.onSaveStateEvent.bind(this));
+    $.subscribe(Events.HISTORY_STATE_LOADED, this.onSaveStateEvent.bind(this));
+    $.subscribe(Events.FRAME_SIZE_CHANGED, this.onSaveStateEvent.bind(this));
 
     // Notify any attached API that piskel is ready to use.
     this.sendMessage_({type: MessageType.PISKEL_API_READY});

--- a/src/js/service/PiskelApiService.js
+++ b/src/js/service/PiskelApiService.js
@@ -128,6 +128,7 @@
   ns.PiskelApiService.prototype.createNewPiskel = function (frameSizeX,
       frameSizeY, frameRate) {
     frameRate = typeof frameRate !== 'undefined' ? frameRate : Constants.DEFAULT.FPS;
+    $.publish(Events.LOAD_NEW_PISKEL);
 
     // Generate a new blank Piskel (document)
     var descriptor = new pskl.model.piskel.Descriptor('New Piskel', '');
@@ -151,6 +152,8 @@
    */
   ns.PiskelApiService.prototype.loadSpritesheet = function (uri, frameSizeX,
       frameSizeY, frameRate) {
+    $.publish(Events.LOAD_NEW_PISKEL);
+
     var image = new Image();
     image.onload = function () {
       // Avoid retriggering image onload (something about JsGif?)

--- a/test/js/service/HistoryServiceTest.js
+++ b/test/js/service/HistoryServiceTest.js
@@ -45,6 +45,36 @@ describe("History Service suite", function() {
     expect(historyService.currentIndex).toBe(0);
   });
 
+  it("is -1 after clearState", function() {
+    historyService = createMockHistoryService();
+    historyService.init();
+    sendSaveEvents(pskl.service.HistoryService.REPLAY).times(3);
+    expect(historyService.currentIndex).toBe(3);
+    historyService.clearState();
+    expect(historyService.currentIndex).toBe(-1);
+    expect(historyService.stateQueue.length).toBe(0);
+  });
+
+  var sendLoadNewPiskelEvent = function () {
+    return callFactory (function () {
+      $.publish(Events.LOAD_NEW_PISKEL, {
+        type : '',
+        scope : {},
+        replay : {}
+      });
+    });
+  };
+
+  it("clears state when loading a new piskel", function() {
+    historyService = createMockHistoryService();
+    historyService.init();
+    sendSaveEvents(pskl.service.HistoryService.REPLAY).times(3);
+    expect(historyService.currentIndex).toBe(3);
+    sendLoadNewPiskelEvent().once();
+    expect(historyService.currentIndex).toBe(-1);
+    expect(historyService.stateQueue.length).toBe(0);
+  });
+
   var sendSaveEvents = function (type) {
     return callFactory (function () {
       $.publish(Events.PISKEL_SAVE_STATE, {


### PR DESCRIPTION
Fixes the following bugs:
- Undo stack shouldn't cross animations
- Undo doesn't save

Do you think this is something we should push upstream too? I'll also add tests once you take a look at the approach. 

Repro Issue 1:
- Draw something in animation 1
- Draw something in animation 2
- Go to animation 1 and hit Ctrl Z

Bug: You end up getting what you drew in animation 2.
Expected: Animation 1's undo stack is independent of animation 2's undo stack.

Repro Issue 2: 
- In Animation tab, draw something in Piskel
- Hit Ctrl Z to undo 
- Switch over to the code tab
- Switch back to the animation tab

Expected: The undo change got saved
Actual: The change didn't get saved (as if you had never done undo). 
