### PR TITLE
Combine two piskels function

### DIFF
--- a/src/js/model/Layer.js
+++ b/src/js/model/Layer.js
@@ -63,6 +63,10 @@
     this.frames.splice(index, 0, frame);
   };
 
+  ns.Layer.prototype.replaceFrameAt = function(frame, index) {
+    this.frames[index] = frame;
+  };
+
   ns.Layer.prototype.removeFrame = function (frame) {
     var index = this.frames.indexOf(frame);
     this.removeFrameAt(index);

--- a/src/js/service/ImportService.js
+++ b/src/js/service/ImportService.js
@@ -137,32 +137,24 @@
    * @returns {pskl.model.Piskel}
    */
   // Adds frames from an additionalPiskel to an originalPiskel, adjusting the size of
-  // both piskels to the largest demensions of either piskel, and centering the content.
+  // both piskels to the largest dimensions of either piskel, and centering the content.
   // This will only work when there is only one layer.
   // Multi layer animations are disabled from the UI in code-dot-org/piskel
-  ns.ImportService.prototype.addTwoPiskels = function(originalPiskel, additionalPiskel) {
+  ns.ImportService.prototype.mergePiskels = function(originalPiskel, additionalPiskel) {
+    if (originalPiskel.layers.length != 1 || originalPiskel.layers.length != 1) {
+      throw new Error(
+        'mergePiskels was provided with piskel parameters with more than one layer');
+    }
+
     var maxWidth = Math.max(originalPiskel.width, additionalPiskel.width);
     var maxHeight = Math.max(originalPiskel.height, additionalPiskel.height);
 
-    if (additionalPiskel.width <= maxWidth && additionalPiskel.height <= maxHeight) {
-      var additionalFrames = additionalPiskel.layers[0].size();
-      for (var j = 0; j < additionalFrames; j++) {
-        var resizedAdditionalFrame = this.resizeFrameToWH(additionalPiskel.layers[0].getFrameAt(j), maxWidth, maxHeight);
-        additionalPiskel.layers[0].replaceFrameAt(resizedAdditionalFrame, j);
-      }
-      additionalPiskel.width = maxWidth;
-      additionalPiskel.height = maxHeight;
+    if (additionalPiskel.width < maxWidth || additionalPiskel.height < maxHeight) {
+      this.resizePiskel(additionalPiskel, maxWidth, maxHeight);
     }
 
-    if (originalPiskel.width <= maxWidth && originalPiskel.height <= maxHeight) {
-      var originalFrames = originalPiskel.layers[0].size();
-      for (var j = 0; j < originalFrames; j++) {
-        var resizedOriginalFrame = this.resizeFrameToWH(originalPiskel.layers[0].getFrameAt(j), maxWidth, maxHeight);
-        originalPiskel.layers[0].replaceFrameAt(resizedOriginalFrame, j);
-      }
-
-      originalPiskel.width = maxWidth;
-      originalPiskel.height = maxHeight;
+    if (originalPiskel.width < maxWidth || originalPiskel.height < maxHeight) {
+      this.resizePiskel(originalPiskel, maxWidth, maxHeight);
     }
 
     for (var i = 0; i < additionalPiskel.layers[0].size(); i++) {
@@ -171,34 +163,35 @@
     return originalPiskel;
   };
 
+  /**
+   * @param {!pskl.model.Piskel} piskel
+   * @param {!number} width
+   * @param {!number} height
+   */
+  ns.ImportService.prototype.resizePiskel = function(piskel, width, height) {
+    var numFrames = piskel.layers[0].size();
+    for (var j = 0; j < numFrames; j++) {
+      var resizedFrame = this.setFrameSize(piskel.layers[0].getFrameAt(j), width, height);
+      piskel.layers[0].replaceFrameAt(resizedFrame, j);
+    }
+    piskel.width = width;
+    piskel.height = height;
+  };
+
   // Modified from ResizeController
-  ns.ImportService.prototype.resizeFrameToWH = function (frame, width, height) {
+  /**
+   * @param {!pskl.model.Frame} frame
+   * @param {!number} width
+   * @param {!number} height
+   * @returns {pskl.model.Frame}
+   */
+  ns.ImportService.prototype.setFrameSize = function (frame, width, height) {
     var resizedFrame = new pskl.model.Frame(width, height);
+    var xOffset = Math.round((width - frame.width) / 2);
+    var yOffset = Math.round((height - frame.height) / 2);
     frame.forEachPixel(function (color, x, y) {
-      var translated = this.translateCoordinates_(x, y, frame, resizedFrame);
-      if (resizedFrame.containsPixel(translated.x, translated.y)) {
-        resizedFrame.setPixel(translated.x, translated.y, color);
-      }
-    }.bind(this));
-
+      resizedFrame.setPixel(x + xOffset, y + yOffset, color);
+    });
     return resizedFrame;
-  };
-
-  // Modified from ResizeController
-  ns.ImportService.prototype.translateCoordinates_ = function (x, y, frame, resizedFrame) {
-    return {
-      x : this.translateX_(x, frame.width, resizedFrame.width),
-      y : this.translateY_(y, frame.height, resizedFrame.height)
-    };
-  };
-
-  // Modified from ResizeController
-  ns.ImportService.prototype.translateX_ = function (x, width, resizedWidth) {
-    return x - Math.round((width - resizedWidth) / 2);
-  };
-
-  // Modified from ResizeController
-  ns.ImportService.prototype.translateY_ = function (y, height, resizedHeight) {
-    return y - Math.round((height - resizedHeight) / 2);
   };
 })();

--- a/src/js/service/ImportService.js
+++ b/src/js/service/ImportService.js
@@ -132,14 +132,14 @@
   };
 
   /**
+   * Adds frames from an additionalPiskel to an originalPiskel, adjusting the size of
+   * both piskels to the largest dimensions of either piskel, and centering the content.
+   * This will only work when there is only one layer.
+   * Multi layer animations are disabled from the UI in code-dot-org/piskel
    * @param {!pskl.model.Piskel} originalPiskel
    * @param {!pskl.model.Piskel} additionalPiskel
    * @returns {pskl.model.Piskel}
    */
-  // Adds frames from an additionalPiskel to an originalPiskel, adjusting the size of
-  // both piskels to the largest dimensions of either piskel, and centering the content.
-  // This will only work when there is only one layer.
-  // Multi layer animations are disabled from the UI in code-dot-org/piskel
   ns.ImportService.prototype.mergePiskels = function(originalPiskel, additionalPiskel) {
     if (originalPiskel.layers.length != 1 || originalPiskel.layers.length != 1) {
       throw new Error(
@@ -149,13 +149,8 @@
     var maxWidth = Math.max(originalPiskel.width, additionalPiskel.width);
     var maxHeight = Math.max(originalPiskel.height, additionalPiskel.height);
 
-    if (additionalPiskel.width < maxWidth || additionalPiskel.height < maxHeight) {
-      this.resizePiskel(additionalPiskel, maxWidth, maxHeight);
-    }
-
-    if (originalPiskel.width < maxWidth || originalPiskel.height < maxHeight) {
-      this.resizePiskel(originalPiskel, maxWidth, maxHeight);
-    }
+    this.resizePiskel(additionalPiskel, maxWidth, maxHeight);
+    this.resizePiskel(originalPiskel, maxWidth, maxHeight);
 
     for (var i = 0; i < additionalPiskel.layers[0].size(); i++) {
       originalPiskel.layers[0].addFrame(additionalPiskel.layers[0].getFrameAt(i));
@@ -169,17 +164,19 @@
    * @param {!number} height
    */
   ns.ImportService.prototype.resizePiskel = function(piskel, width, height) {
-    var numFrames = piskel.layers[0].size();
-    for (var j = 0; j < numFrames; j++) {
-      var resizedFrame = this.setFrameSize(piskel.layers[0].getFrameAt(j), width, height);
-      piskel.layers[0].replaceFrameAt(resizedFrame, j);
+    if (piskel.width < width || piskel.height < height) {
+      var numFrames = piskel.layers[0].size();
+      for (var j = 0; j < numFrames; j++) {
+        var resizedFrame = this.setFrameSize(piskel.layers[0].getFrameAt(j), width, height);
+        piskel.layers[0].replaceFrameAt(resizedFrame, j);
+      }
+      piskel.width = width;
+      piskel.height = height;
     }
-    piskel.width = width;
-    piskel.height = height;
   };
 
-  // Modified from ResizeController
   /**
+   * Modified from ResizeController
    * @param {!pskl.model.Frame} frame
    * @param {!number} width
    * @param {!number} height

--- a/src/js/service/ImportService.js
+++ b/src/js/service/ImportService.js
@@ -41,8 +41,7 @@
     var setPiskelFromFrameImages = function (frameImages) {
       var piskel = this.createPiskelFromImages_(frameImages, frameSizeX,
           frameSizeY, smoothing);
-      var addedPiskel = this.addTwoPiskels(this.piskelController_.getPiskel(), piskel);
-      this.piskelController_.setPiskel(addedPiskel);
+      this.piskelController_.setPiskel(piskel);
       this.previewController_.setFPS(frameRate);
     }.bind(this);
 

--- a/src/js/service/ImportService.js
+++ b/src/js/service/ImportService.js
@@ -41,7 +41,8 @@
     var setPiskelFromFrameImages = function (frameImages) {
       var piskel = this.createPiskelFromImages_(frameImages, frameSizeX,
           frameSizeY, smoothing);
-      this.piskelController_.setPiskel(piskel);
+      var addedPiskel = this.addTwoPiskels(this.piskelController_.getPiskel(), piskel);
+      this.piskelController_.setPiskel(addedPiskel);
       this.previewController_.setFPS(frameRate);
     }.bind(this);
 
@@ -129,5 +130,76 @@
       var resizedImage = pskl.utils.ImageResizer.resize(image, frameSizeX, frameSizeY, smoothing);
       return pskl.utils.FrameUtils.createFromImage(resizedImage);
     });
+  };
+
+  /**
+   * @param {pskl.model.Piskel} originalPiskel
+   * @param {pskl.model.Piskel} additionalPiskel
+   * @returns {pskl.model.Piskel}
+   */
+  // Adds frames from an additionalPiskel to an originalPiskel, adjusting the size of
+  // both piskels to the largest demensions of either piskel, and centering the content.
+  // This will only work when there is only one layer.
+  // Multi layer animations are disabled from the UI in code-dot-org/piskel
+  ns.ImportService.prototype.addTwoPiskels = function(originalPiskel, additionalPiskel) {
+    var maxWidth = Math.max(originalPiskel.width, additionalPiskel.width);
+    var maxHeight = Math.max(originalPiskel.height, additionalPiskel.height);
+
+    if (additionalPiskel.width <= maxWidth && additionalPiskel.height <= maxHeight) {
+      var additionalFrames = additionalPiskel.layers[0].size();
+      for (var j = 0; j < additionalFrames; j++) {
+        var resizedAdditionalFrame = this.resizeFrameToWH(additionalPiskel.layers[0].getFrameAt(j), maxWidth, maxHeight)
+        additionalPiskel.layers[0].replaceFrameAt(resizedAdditionalFrame, j);
+      }
+      additionalPiskel.width = maxWidth;
+      additionalPiskel.height = maxHeight;
+    }
+
+    if (originalPiskel.width <= maxWidth && originalPiskel.height <= maxHeight) {
+      var originalFrames = originalPiskel.layers[0].size();
+      for (var j = 0; j < originalFrames; j++) {
+        var resizedOriginalFrame = this.resizeFrameToWH(originalPiskel.layers[0].getFrameAt(j), maxWidth, maxHeight)
+        originalPiskel.layers[0].replaceFrameAt(resizedOriginalFrame, j);
+      }
+      
+      originalPiskel.width = maxWidth;
+      originalPiskel.height = maxHeight;  
+    }
+
+    for(var i = 0; i < additionalPiskel.layers[0].size(); i++) {
+      originalPiskel.layers[0].addFrame(additionalPiskel.layers[0].getFrameAt(i));
+    }
+    return originalPiskel;
+  };
+
+  // Modified from ResizeController
+  ns.ImportService.prototype.resizeFrameToWH = function (frame, width, height) {
+    var resizedFrame = new pskl.model.Frame(width, height);
+    frame.forEachPixel(function (color, x, y) {
+      var translated = this.translateCoordinates_(x, y, frame, resizedFrame);
+      if (resizedFrame.containsPixel(translated.x, translated.y)) {
+        resizedFrame.setPixel(translated.x, translated.y, color);
+      }
+    }.bind(this));
+
+    return resizedFrame;
+  };
+
+  // Modified from ResizeController
+  ns.ImportService.prototype.translateCoordinates_ = function (x, y, frame, resizedFrame) {
+    return {
+      x : this.translateX_(x, frame.width, resizedFrame.width),
+      y : this.translateY_(y, frame.height, resizedFrame.height)
+    };
+  };
+
+  // Modified from ResizeController
+  ns.ImportService.prototype.translateX_ = function (x, width, resizedWidth) {
+    return x - Math.round((width - resizedWidth) / 2);
+  };
+
+  // Modified from ResizeController
+  ns.ImportService.prototype.translateY_ = function (y, height, resizedHeight) {
+    return y - Math.round((height - resizedHeight) / 2);
   };
 })();

--- a/src/js/service/ImportService.js
+++ b/src/js/service/ImportService.js
@@ -132,8 +132,8 @@
   };
 
   /**
-   * @param {pskl.model.Piskel} originalPiskel
-   * @param {pskl.model.Piskel} additionalPiskel
+   * @param {!pskl.model.Piskel} originalPiskel
+   * @param {!pskl.model.Piskel} additionalPiskel
    * @returns {pskl.model.Piskel}
    */
   // Adds frames from an additionalPiskel to an originalPiskel, adjusting the size of

--- a/src/js/service/ImportService.js
+++ b/src/js/service/ImportService.js
@@ -147,7 +147,7 @@
     if (additionalPiskel.width <= maxWidth && additionalPiskel.height <= maxHeight) {
       var additionalFrames = additionalPiskel.layers[0].size();
       for (var j = 0; j < additionalFrames; j++) {
-        var resizedAdditionalFrame = this.resizeFrameToWH(additionalPiskel.layers[0].getFrameAt(j), maxWidth, maxHeight)
+        var resizedAdditionalFrame = this.resizeFrameToWH(additionalPiskel.layers[0].getFrameAt(j), maxWidth, maxHeight);
         additionalPiskel.layers[0].replaceFrameAt(resizedAdditionalFrame, j);
       }
       additionalPiskel.width = maxWidth;
@@ -157,15 +157,15 @@
     if (originalPiskel.width <= maxWidth && originalPiskel.height <= maxHeight) {
       var originalFrames = originalPiskel.layers[0].size();
       for (var j = 0; j < originalFrames; j++) {
-        var resizedOriginalFrame = this.resizeFrameToWH(originalPiskel.layers[0].getFrameAt(j), maxWidth, maxHeight)
+        var resizedOriginalFrame = this.resizeFrameToWH(originalPiskel.layers[0].getFrameAt(j), maxWidth, maxHeight);
         originalPiskel.layers[0].replaceFrameAt(resizedOriginalFrame, j);
       }
-      
+
       originalPiskel.width = maxWidth;
-      originalPiskel.height = maxHeight;  
+      originalPiskel.height = maxHeight;
     }
 
-    for(var i = 0; i < additionalPiskel.layers[0].size(); i++) {
+    for (var i = 0; i < additionalPiskel.layers[0].size(); i++) {
       originalPiskel.layers[0].addFrame(additionalPiskel.layers[0].getFrameAt(i));
     }
     return originalPiskel;

--- a/test/js/service/ImportServiceTest.js
+++ b/test/js/service/ImportServiceTest.js
@@ -1,0 +1,84 @@
+
+describe("ImportService test suite", function() {
+  var createPiskel = function(width, height, numFrames) {
+    var descriptor = 10;
+    var piskel = new pskl.model.Piskel(width, height, descriptor);
+    var layer = new pskl.model.Layer("layer 1");
+    for (var i = 0; i < numFrames; i++) {
+      var frame = new pskl.model.Frame(width, height);
+      layer.addFrame(frame);
+    }
+    piskel.addLayer(layer);
+    return piskel;
+  };
+
+  it("mergePiskels combines two same size piskels", function() {
+    var service = new pskl.service.ImportService();
+
+    var piskel1 = createPiskel(10, 10, 2);
+    var piskel2 = createPiskel(10, 10, 1);
+    var mergedPiskels = service.mergePiskels(piskel1, piskel2);
+
+    expect(mergedPiskels.layers[0].size()).toBe(3);
+    expect(mergedPiskels.width).toBe(10);
+    expect(mergedPiskels.height).toBe(10);
+    expect(mergedPiskels.layers[0].getFrameAt(0).width).toBe(10);
+    expect(mergedPiskels.layers[0].getFrameAt(1).width).toBe(10);
+    expect(mergedPiskels.layers[0].getFrameAt(2).width).toBe(10);
+    expect(mergedPiskels.layers[0].getFrameAt(0).height).toBe(10);
+    expect(mergedPiskels.layers[0].getFrameAt(1).height).toBe(10);
+    expect(mergedPiskels.layers[0].getFrameAt(2).height).toBe(10);
+  });
+
+  it("mergePiskels combines two different size piskels", function() {
+    var service = new pskl.service.ImportService();
+
+    var piskel1 = createPiskel(10, 10, 1);
+    var piskel2 = createPiskel(20, 20, 3);
+    var mergedPiskels = service.mergePiskels(piskel1, piskel2);
+
+    expect(mergedPiskels.layers[0].size()).toBe(4);
+    expect(mergedPiskels.width).toBe(20);
+    expect(mergedPiskels.height).toBe(20);
+    expect(mergedPiskels.layers[0].getFrameAt(0).width).toBe(20);
+    expect(mergedPiskels.layers[0].getFrameAt(1).width).toBe(20);
+    expect(mergedPiskels.layers[0].getFrameAt(2).width).toBe(20);
+    expect(mergedPiskels.layers[0].getFrameAt(3).width).toBe(20);
+    expect(mergedPiskels.layers[0].getFrameAt(0).height).toBe(20);
+    expect(mergedPiskels.layers[0].getFrameAt(1).height).toBe(20);
+    expect(mergedPiskels.layers[0].getFrameAt(2).height).toBe(20);
+    expect(mergedPiskels.layers[0].getFrameAt(3).height).toBe(20);
+
+    var piskel3 = createPiskel(20, 20, 3);
+    var piskel4 = createPiskel(10, 10, 1);
+    var mergedPiskels2 = service.mergePiskels(piskel3, piskel4);
+
+    expect(mergedPiskels2.layers[0].size()).toBe(4);
+    expect(mergedPiskels2.width).toBe(20);
+    expect(mergedPiskels2.height).toBe(20);
+    expect(mergedPiskels2.layers[0].getFrameAt(0).width).toBe(20);
+    expect(mergedPiskels2.layers[0].getFrameAt(1).width).toBe(20);
+    expect(mergedPiskels2.layers[0].getFrameAt(2).width).toBe(20);
+    expect(mergedPiskels2.layers[0].getFrameAt(3).width).toBe(20);
+    expect(mergedPiskels2.layers[0].getFrameAt(0).height).toBe(20);
+    expect(mergedPiskels2.layers[0].getFrameAt(1).height).toBe(20);
+    expect(mergedPiskels2.layers[0].getFrameAt(2).height).toBe(20);
+    expect(mergedPiskels2.layers[0].getFrameAt(3).height).toBe(20);
+
+    var piskel5 = createPiskel(30, 20, 2);
+    var piskel6 = createPiskel(10, 40, 2);
+    var mergedPiskels3 = service.mergePiskels(piskel5, piskel6);
+
+    expect(mergedPiskels3.layers[0].size()).toBe(4);
+    expect(mergedPiskels3.width).toBe(30);
+    expect(mergedPiskels3.height).toBe(40);
+    expect(mergedPiskels3.layers[0].getFrameAt(0).width).toBe(30);
+    expect(mergedPiskels3.layers[0].getFrameAt(1).width).toBe(30);
+    expect(mergedPiskels3.layers[0].getFrameAt(2).width).toBe(30);
+    expect(mergedPiskels3.layers[0].getFrameAt(3).width).toBe(30);
+    expect(mergedPiskels3.layers[0].getFrameAt(0).height).toBe(40);
+    expect(mergedPiskels3.layers[0].getFrameAt(1).height).toBe(40);
+    expect(mergedPiskels3.layers[0].getFrameAt(2).height).toBe(40);
+    expect(mergedPiskels3.layers[0].getFrameAt(3).height).toBe(40);
+  });
+});

--- a/test/js/service/ImportServiceTest.js
+++ b/test/js/service/ImportServiceTest.js
@@ -12,73 +12,106 @@ describe("ImportService test suite", function() {
     return piskel;
   };
 
+  var color = 'rgb(1, 1, 1)';
+
   it("mergePiskels combines two same size piskels", function() {
     var service = new pskl.service.ImportService();
 
     var piskel1 = createPiskel(10, 10, 2);
     var piskel2 = createPiskel(10, 10, 1);
+    piskel1.layers[0].getFrameAt(0).setPixel(1, 1, color);
+    piskel1.layers[0].getFrameAt(1).setPixel(1, 2, color);
+    piskel2.layers[0].getFrameAt(0).setPixel(2, 1, color);
     var mergedPiskels = service.mergePiskels(piskel1, piskel2);
-
+    
+    // Check that sizes are the same.
     expect(mergedPiskels.layers[0].size()).toBe(3);
     expect(mergedPiskels.width).toBe(10);
     expect(mergedPiskels.height).toBe(10);
-    expect(mergedPiskels.layers[0].getFrameAt(0).width).toBe(10);
-    expect(mergedPiskels.layers[0].getFrameAt(1).width).toBe(10);
-    expect(mergedPiskels.layers[0].getFrameAt(2).width).toBe(10);
-    expect(mergedPiskels.layers[0].getFrameAt(0).height).toBe(10);
-    expect(mergedPiskels.layers[0].getFrameAt(1).height).toBe(10);
-    expect(mergedPiskels.layers[0].getFrameAt(2).height).toBe(10);
+    mergedPiskels.layers[0].frames.forEach(function (frame) {
+      expect(frame.width).toBe(10);
+      expect(frame.height).toBe(10);
+    });
+
+    // Check that frames are in the right order and pixels are in the right place.
+    expect(mergedPiskels.layers[0].getFrameAt(0).getPixel(1,1)).toBe(color);
+    expect(mergedPiskels.layers[0].getFrameAt(1).getPixel(1,2)).toBe(color);
+    expect(mergedPiskels.layers[0].getFrameAt(2).getPixel(2,1)).toBe(color);
   });
 
   it("mergePiskels combines two different size piskels", function() {
     var service = new pskl.service.ImportService();
 
+    // PISKELS 1 AND 2
     var piskel1 = createPiskel(10, 10, 1);
     var piskel2 = createPiskel(20, 20, 3);
+    piskel1.layers[0].getFrameAt(0).setPixel(1, 1, color);
+    piskel2.layers[0].getFrameAt(0).setPixel(1, 2, color);
+    piskel2.layers[0].getFrameAt(1).setPixel(2, 1, color);
+    piskel2.layers[0].getFrameAt(2).setPixel(2, 2, color);
     var mergedPiskels = service.mergePiskels(piskel1, piskel2);
 
+    // Check that sizes are the same.
     expect(mergedPiskels.layers[0].size()).toBe(4);
     expect(mergedPiskels.width).toBe(20);
     expect(mergedPiskels.height).toBe(20);
-    expect(mergedPiskels.layers[0].getFrameAt(0).width).toBe(20);
-    expect(mergedPiskels.layers[0].getFrameAt(1).width).toBe(20);
-    expect(mergedPiskels.layers[0].getFrameAt(2).width).toBe(20);
-    expect(mergedPiskels.layers[0].getFrameAt(3).width).toBe(20);
-    expect(mergedPiskels.layers[0].getFrameAt(0).height).toBe(20);
-    expect(mergedPiskels.layers[0].getFrameAt(1).height).toBe(20);
-    expect(mergedPiskels.layers[0].getFrameAt(2).height).toBe(20);
-    expect(mergedPiskels.layers[0].getFrameAt(3).height).toBe(20);
+    mergedPiskels.layers[0].frames.forEach(function (frame) {
+      expect(frame.width).toBe(20);
+      expect(frame.height).toBe(20);
+    });
 
+    // Check that frames are in the right order and pixels are in the right place.
+    expect(mergedPiskels.layers[0].getFrameAt(0).getPixel(6,6)).toBe(color);
+    expect(mergedPiskels.layers[0].getFrameAt(1).getPixel(1,2)).toBe(color);
+    expect(mergedPiskels.layers[0].getFrameAt(2).getPixel(2,1)).toBe(color);
+    expect(mergedPiskels.layers[0].getFrameAt(3).getPixel(2,2)).toBe(color);
+
+    // PISKELS 3 AND 4
     var piskel3 = createPiskel(20, 20, 3);
     var piskel4 = createPiskel(10, 10, 1);
+    piskel3.layers[0].getFrameAt(0).setPixel(2, 2, color);
+    piskel3.layers[0].getFrameAt(1).setPixel(3, 3, color);
+    piskel3.layers[0].getFrameAt(2).setPixel(4, 4, color);
+    piskel4.layers[0].getFrameAt(0).setPixel(5, 5, color);
     var mergedPiskels2 = service.mergePiskels(piskel3, piskel4);
 
+    // Check that sizes are the same.
     expect(mergedPiskels2.layers[0].size()).toBe(4);
     expect(mergedPiskels2.width).toBe(20);
     expect(mergedPiskels2.height).toBe(20);
-    expect(mergedPiskels2.layers[0].getFrameAt(0).width).toBe(20);
-    expect(mergedPiskels2.layers[0].getFrameAt(1).width).toBe(20);
-    expect(mergedPiskels2.layers[0].getFrameAt(2).width).toBe(20);
-    expect(mergedPiskels2.layers[0].getFrameAt(3).width).toBe(20);
-    expect(mergedPiskels2.layers[0].getFrameAt(0).height).toBe(20);
-    expect(mergedPiskels2.layers[0].getFrameAt(1).height).toBe(20);
-    expect(mergedPiskels2.layers[0].getFrameAt(2).height).toBe(20);
-    expect(mergedPiskels2.layers[0].getFrameAt(3).height).toBe(20);
+    mergedPiskels2.layers[0].frames.forEach(function (frame) {
+      expect(frame.width).toBe(20);
+      expect(frame.height).toBe(20);
+    });
 
+    // Check that frames are in the right order and pixels are in the right place.
+    expect(mergedPiskels2.layers[0].getFrameAt(0).getPixel(2,2)).toBe(color);
+    expect(mergedPiskels2.layers[0].getFrameAt(1).getPixel(3,3)).toBe(color);
+    expect(mergedPiskels2.layers[0].getFrameAt(2).getPixel(4,4)).toBe(color);
+    expect(mergedPiskels2.layers[0].getFrameAt(3).getPixel(10,10)).toBe(color);
+
+    // PISKELS 5 AND 6
     var piskel5 = createPiskel(30, 20, 2);
     var piskel6 = createPiskel(10, 40, 2);
+    piskel5.layers[0].getFrameAt(0).setPixel(2, 2, color);
+    piskel5.layers[0].getFrameAt(1).setPixel(3, 3, color);
+    piskel6.layers[0].getFrameAt(0).setPixel(4, 4, color);
+    piskel6.layers[0].getFrameAt(1).setPixel(5, 5, color);
     var mergedPiskels3 = service.mergePiskels(piskel5, piskel6);
 
+    // Check that sizes are the same.
     expect(mergedPiskels3.layers[0].size()).toBe(4);
     expect(mergedPiskels3.width).toBe(30);
     expect(mergedPiskels3.height).toBe(40);
-    expect(mergedPiskels3.layers[0].getFrameAt(0).width).toBe(30);
-    expect(mergedPiskels3.layers[0].getFrameAt(1).width).toBe(30);
-    expect(mergedPiskels3.layers[0].getFrameAt(2).width).toBe(30);
-    expect(mergedPiskels3.layers[0].getFrameAt(3).width).toBe(30);
-    expect(mergedPiskels3.layers[0].getFrameAt(0).height).toBe(40);
-    expect(mergedPiskels3.layers[0].getFrameAt(1).height).toBe(40);
-    expect(mergedPiskels3.layers[0].getFrameAt(2).height).toBe(40);
-    expect(mergedPiskels3.layers[0].getFrameAt(3).height).toBe(40);
+    mergedPiskels3.layers[0].frames.forEach(function (frame) {
+      expect(frame.width).toBe(30);
+      expect(frame.height).toBe(40);
+    });
+
+    // Check that frames are in the right order and pixels are in the right place.
+    expect(mergedPiskels3.layers[0].getFrameAt(0).getPixel(2,12)).toBe(color);
+    expect(mergedPiskels3.layers[0].getFrameAt(1).getPixel(3,13)).toBe(color);
+    expect(mergedPiskels3.layers[0].getFrameAt(2).getPixel(14,4)).toBe(color);
+    expect(mergedPiskels3.layers[0].getFrameAt(3).getPixel(15,5)).toBe(color);
   });
 });


### PR DESCRIPTION
I plan on using this function in an exposed PiskelApi so that we can eventually expose uploading custom files per frame, but I'd like to get a review before moving forward. This is a non-breaking change so everything that's here should be fine to merge.

To test this locally, replace `ImportService.js` line 44 with:
```
var combinedPiskel = this.addTwoPiskels(this.piskelController_.getPiskel(), piskel);
this.piskelController_.setPiskel(combinedPiskel);
```
Then in `gamelab.css`, remove `.icon-settings-open-folder-white,` from the first rule.
The import tab will then act like "Add a custom frame" so you can test out different types of uploads and sizes.

cc: @Bjvanminnen 