### PR TITLE
Duplicate (previously ctrl+c/+v) fixes

### DIFF
--- a/src/js/selection/SelectionManager.js
+++ b/src/js/selection/SelectionManager.js
@@ -112,16 +112,16 @@
   };
 
   ns.SelectionManager.prototype.paste = function(quickKey) {
-    // Amount of pixels to offset the paste by.
-    // When the paste is trigged by the quickKey Ctrl+V, offset the pasted overlay by 1.
-    var offset = quickKey === 'V' ? 1 : 0;
-
     if (!this.currentSelection || !this.currentSelection.hasPastedContent) {
       return;
     }
 
     var pixels = this.currentSelection.pixels;
     var frame = this.piskelController.getCurrentFrame();
+
+    // Amount of pixels to offset the paste by.
+    // When the paste is trigged by the quickKey Ctrl+V, offset the pasted overlay by a scaled value.
+    var offset = quickKey === 'V' ? Math.ceil(Math.max(frame.width, frame.height)/50) : 0;
 
     this.pastePixels_(frame, pixels);
     $.publish(Events.PISKEL_SAVE_STATE, {
@@ -187,6 +187,7 @@
   ns.SelectionManager.prototype.copy = function() {
     if (this.currentSelection && this.piskelController.getCurrentFrame()) {
       this.currentSelection.fillSelectionFromFrame(this.piskelController.getCurrentFrame());
+      this.paste('V');
     }
   };
 

--- a/src/js/selection/SelectionManager.js
+++ b/src/js/selection/SelectionManager.js
@@ -121,7 +121,7 @@
 
     // Amount of pixels to offset the paste by.
     // When the paste is trigged by the quickKey Ctrl+V, offset the pasted overlay by a scaled value.
-    var offset = quickKey === 'V' ? Math.ceil(Math.max(frame.width, frame.height)/50) : 0;
+    var offset = quickKey === 'V' ? Math.ceil(Math.max(frame.width, frame.height) / 50) : 0;
 
     this.pastePixels_(frame, pixels);
     $.publish(Events.PISKEL_SAVE_STATE, {

--- a/src/js/tools/drawing/selection/BaseSelect.js
+++ b/src/js/tools/drawing/selection/BaseSelect.js
@@ -22,8 +22,7 @@
 
     this.tooltipDescriptors = [
       {description : 'Drag the selection to move it. You may switch to other layers and frames.'},
-      {key : 'ctrl+c', description : 'Copy the selected area'},
-      {key : 'ctrl+v', description : 'Paste the copied area'},
+      {key : 'ctrl+c', description : 'Duplicate the selected area'},
       {key : 'shift', description : 'Hold to move the content'}
     ];
     if (!Constants.ENABLE_MULTIPLE_LAYERS) {

--- a/test/js/selection/SelectionManagerTest.js
+++ b/test/js/selection/SelectionManagerTest.js
@@ -181,6 +181,18 @@ describe("SelectionManager suite", function() {
     ]);
   });
 
+  it("_getBottomRightCorner finds the coordinates of the bottom right of a rectangular selection", function () {
+    var pixels = [{col: 1, row: 1}, {col: 1, row: 2}, {col: 2, row: 1}, {col: 2, row: 2}];
+    expect(selectionManager._getBottomRightCorner(pixels).x).toBe(2);
+    expect(selectionManager._getBottomRightCorner(pixels).y).toBe(2);
+  });
+
+  it("_getBottomRightCorner finds the coordinates of the bottom right of a irregular selection", function () {
+    var pixels = [{col: 1, row: 1}, {col: 1, row: 2}, {col: 2, row: 1}];
+    expect(selectionManager._getBottomRightCorner(pixels).x).toBe(2);
+    expect(selectionManager._getBottomRightCorner(pixels).y).toBe(2);
+  });
+
   // Private helpers
   var createPixel = function(row, col, color) {
     return {


### PR DESCRIPTION
Ran some ad-hoc user tests with Poorva and we're finding copy and paste really undiscoverable. We're changing it to duplicate, which basically means have copy do a paste with offset. I also added some tests that I committed to in a previous PR of copy/paste.

Updates to the spec: 
- Ctrl C should offset the duplicated item (like Ctrl V does right now)
- Update tooltip for Ctrl C to say "Duplicate the selected area " instead of "Copy the selected area"
- Take out references to Ctrl V
- Is it easy to make offset be a function of the display size?  I'm thinking something like - ceil(max(width, height)/100).  So for images < 100px, the offset is 1px.  For image that are 400px, the offset would be 4px. 

Still to fix in another PR: 
Fix copy paste bug where selected area pastes across different sequences