### PR TITLE
Unleash snap-crop

### DIFF
--- a/src/css/gamelab.css
+++ b/src/css/gamelab.css
@@ -167,7 +167,7 @@ body {
   background-color: transparent;
   border: none;
   width: 60px;
-  height: 170px;
+  height: 230px;
   position: absolute;
   left: -6px;
   top: 50px;


### PR DESCRIPTION
Adding the snap-crop button to our piskel fork.

Post-cropped image shown in local piskel with snap-crop button on left side of screen:
![snapcrop](https://user-images.githubusercontent.com/2959170/35890450-b08e36dc-0b54-11e8-8569-be045144be3a.png)
