### PR TITLE
Handle loading empty spritesheet - add single blank frame.

### DIFF
--- a/src/js/utils/CanvasUtils.js
+++ b/src/js/utils/CanvasUtils.js
@@ -73,7 +73,7 @@
 
         // If last time through loop and canvasArray is empty, we're loading a blank
         // animation and want to push a blank frame to the canvas array
-        const lastFrame = (x + (2*width) > image.width) && (y + (2*height) > image.height);
+        const lastFrame = (x + (2 * width) > image.width) && (y + (2 * height) > image.height);
         const canvasArrayIsEmpty = canvasArray.length === 0;
         const lastChanceToPushFrame = lastFrame && canvasArrayIsEmpty;
 

--- a/src/js/utils/CanvasUtils.js
+++ b/src/js/utils/CanvasUtils.js
@@ -43,7 +43,8 @@
      * @param {Number} height The height of an individual frame
      * @param {Boolean} useHorizonalStrips True if the frames should be layed out from left to
      * right, False if it should use top to bottom
-     * @param {Boolean} ignoreEmptyFrames True to ignore empty frames, false to keep them
+     * @param {Boolean} ignoreEmptyFrames True to ignore empty frames, except if
+     * there are only empty frames -> then keep one, false to keep them.
      * @returns {Array} An array of canvas elements that contain the split frames
      */
     createFramesFromImage : function (image, offsetX, offsetY, width, height, useHorizonalStrips, ignoreEmptyFrames) {
@@ -69,7 +70,16 @@
           width,
           height);
 
-        if (!ignoreEmptyFrames || canvas.toDataURL() !== blankData) {
+
+        // If last time through loop and canvasArray is empty, we're loading a blank
+        // animation and want to push a blank frame to the canvas array
+        const lastFrame = (x + (2*width) > image.width) && (y + (2*height) > image.height);
+        const canvasArrayIsEmpty = canvasArray.length === 0;
+        const lastChanceToPushFrame = lastFrame && canvasArrayIsEmpty;
+
+        // If we are including empty frame, the canvas is not blank, or it's the last chance
+        // to push any frame, push the frame.
+        if (!ignoreEmptyFrames || canvas.toDataURL() !== blankData || lastChanceToPushFrame) {
           canvasArray.push(canvas);
         }
 

--- a/test/js/utils/CanvasUtilsTest.js
+++ b/test/js/utils/CanvasUtilsTest.js
@@ -1,15 +1,28 @@
 describe("Canvas utils", function() {
 
-  it("returns a single blank frame when provided a blank spritesheet set to ignore blank frames", function() {
-    var width = 10;
-    var height = 10;
-    var blankData = pskl.utils.CanvasUtils.createCanvas(width, height).toDataURL();
-    var blankImg = new Image(width, height);
+  it("returns a single blank frame when provided a small blank spritesheet set to ignore blank frames", function() {
+    var imageSize = 10;
+    var blankData = pskl.utils.CanvasUtils.createCanvas(imageSize, imageSize).toDataURL();
+    var blankImg = new Image(imageSize, imageSize);
     blankImg.src = blankData;
 
-    var blankSpritesheetFrames = pskl.utils.CanvasUtils.createFramesFromImage(blankImg, 0, 0, width, height, true, true);
+    var blankSpritesheetFrames = pskl.utils.CanvasUtils.createFramesFromImage(blankImg, 0, 0, imageSize, imageSize, true, true);
 
     expect(blankSpritesheetFrames.length).toBe(1);
     expect(blankSpritesheetFrames[0].toDataURL()).toBe(blankData);
+  });
+
+  it("returns a single blank frame when provided a large blank spritesheet set to ignore blank frames", function() {
+    var imageSize = 50;
+    var frameSize = 10;
+    var blankData = pskl.utils.CanvasUtils.createCanvas(imageSize, imageSize).toDataURL();
+    var blankImg = new Image(imageSize, imageSize);
+    blankImg.src = blankData;
+
+    var blankSpritesheetFrames = pskl.utils.CanvasUtils.createFramesFromImage(blankImg, 0, 0, frameSize, frameSize, true, true);
+
+    expect(blankSpritesheetFrames.length).toBe(1);
+    expect(blankSpritesheetFrames[0].width).toBe(frameSize);
+    expect(blankSpritesheetFrames[0].height).toBe(frameSize);
   });
 });

--- a/test/js/utils/CanvasUtilsTest.js
+++ b/test/js/utils/CanvasUtilsTest.js
@@ -1,0 +1,15 @@
+describe("Canvas utils", function() {
+
+  it("returns a single blank frame when provided a blank spritesheet set to ignore blank frames", function() {
+    var width = 10;
+    var height = 10;
+    var blankData = pskl.utils.CanvasUtils.createCanvas(width, height).toDataURL();
+    var blankImg = new Image(width, height);
+    blankImg.src = blankData;
+
+    var blankSpritesheetFrames = pskl.utils.CanvasUtils.createFramesFromImage(blankImg, 0, 0, width, height, true, true);
+
+    expect(blankSpritesheetFrames.length).toBe(1);
+    expect(blankSpritesheetFrames[0].toDataURL()).toBe(blankData);
+  });
+});


### PR DESCRIPTION
Update how we create frames from an image. If all the frames in the image are blank, add a single empty frame. This allows us to use blank images in piskel (if a student wants to draw an animation but moves on before making any changes).