### PR TITLE
Enable export functionality

### DIFF
--- a/src/css/gamelab.css
+++ b/src/css/gamelab.css
@@ -390,3 +390,7 @@ a, a:visited {
 .tab-item.selected {
   border-color: #fff;
 }
+
+span.highlight {
+  color:#7665a0;
+}

--- a/src/css/gamelab.css
+++ b/src/css/gamelab.css
@@ -1,5 +1,4 @@
 /* Features to hide on GameLab Animation tab */
-.icon-settings-export-white,
 .palettes-list-container,
 .cheatsheet-link,
 .canvas-container-wrapper,
@@ -11,7 +10,10 @@
 .icon-settings-gear-white,
 .transformations-title,
 .top-overflow,
-.bottom-overflow {
+.bottom-overflow,
+[data-tab-id=png],
+[data-tab-id=misc],
+.upload-gif-gamelab{
   padding: 0px;
   visibility: hidden;
   min-height: 0px;
@@ -59,25 +61,33 @@ body {
   left: 120px;
 }
 
-/*Resize */
+/*Resize and Export*/
 
 .right-sticky-section .tool-icon.has-expanded-drawer {
   border: none;
   background-color: #444;
 }
 
-.tool-icon.icon-settings-resize-white {
-  height: 160px;
+.tool-icon.icon-settings-resize-white,
+.tool-icon.icon-settings-export-white {
+  height: 50px;
   background-color: #7665a0;
   border-left: none;
   border-top: none;
   border-bottom: none;
-  background-image: url(../img/icons/settings/settings-resize-white.png);
   background-repeat: no-repeat;
   background-position: 0;
   background-size: 46px;
   border-bottom-left-radius: 5px;
   border-top-left-radius: 5px;
+}
+
+.tool-icon.icon-settings-resize-white{
+  background-image: url(../img/icons/settings/settings-resize-white.png);
+}
+
+.tool-icon.icon-settings-export-white{
+  background-image: url(../img/icons/settings/settings-export-white.png);
 }
 
 /* Onion */
@@ -366,4 +376,17 @@ a, a:visited {
 
 .cursor-coordinates {
   color: #7665a0;
+}
+
+.tab-list:after {
+  background-color: #fff;
+}
+
+.tab-item.selected,
+.tab-item:hover {
+  color: #FFF;
+}
+
+.tab-item.selected {
+  border-color: #fff;
 }

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -6,11 +6,10 @@
     rel="tooltip" data-placement="left">
   </div>
 
-  <!-- Code.org changed colour to purple to match style -->
   <div
     data-setting="resize"
     class="tool-icon  icon-settings-resize-white"
-    title="<span style='color:#7665a0'>RESIZE</span></br>Resize the drawing area"
+    title="<span class='highlight'>RESIZE</span></br>Resize the drawing area"
     rel="tooltip" data-placement="left">
   </div>
 
@@ -24,7 +23,7 @@
   <div
     data-setting="export"
     class="tool-icon  icon-settings-export-white"
-    title="<span style='color:#7665a0'>EXPORT</span></br>Export as Image, as Spritesheet<br/>or as Animated GIF"
+    title="<span class='highlight'>EXPORT</span></br>Export as Image, as Spritesheet<br/>or as Animated GIF"
     rel="tooltip" data-placement="left">
   </div>
 

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -24,7 +24,7 @@
   <div
     data-setting="export"
     class="tool-icon  icon-settings-export-white"
-    title="<span class='highlight'>EXPORT</span></br>Export as Image, as Spritesheet<br/>or as Animated GIF"
+    title="<span style='color:#7665a0'>EXPORT</span></br>Export as Image, as Spritesheet<br/>or as Animated GIF"
     rel="tooltip" data-placement="left">
   </div>
 

--- a/src/templates/settings/export/gif.html
+++ b/src/templates/settings/export/gif.html
@@ -20,7 +20,8 @@
       <button type="button" class="button button-primary gif-download-button">Download</button>
       <div class="export-info">Download as an animated GIF.</div>
     </div>
-    <div class="export-panel-section export-panel-row">
+    <!-- GAMELAB : Adding classname to be able to hide this feature-->
+    <div class="export-panel-section export-panel-row upload-gif-gamelab">
       <button type="button" class="button button-primary gif-upload-button">Upload</button>
       <div class="export-info">Upload as an animated GIF to a public URL.</div>
     </div>


### PR DESCRIPTION
Enables the ability to export gifs and zips from piskel, according to this spec: https://codeorg.axosoft.com/viewitem?id=1348&type=features&force_use_number=true

Screenshots:
![screenshot from 2018-04-18 17-21-58](https://user-images.githubusercontent.com/2959170/38964814-c389bd72-432d-11e8-8650-0b1797a4ff0c.png)
![screenshot from 2018-04-18 17-21-47](https://user-images.githubusercontent.com/2959170/38964816-c678d482-432d-11e8-896e-f641a7f601b2.png)
