### PR TITLE
Enable restricted tools mode to hide a subset of editing tools.

### DIFF
--- a/src/css/gamelab.css
+++ b/src/css/gamelab.css
@@ -13,13 +13,18 @@
 .bottom-overflow,
 [data-tab-id=png],
 [data-tab-id=misc],
-.upload-gif-gamelab{
+.upload-gif-gamelab,
+.spritelab-hide{
   padding: 0px;
   visibility: hidden;
   min-height: 0px;
   height: 0px;
   width: 0px;
   margin: 0px;
+}
+
+.spritelab-hide{
+  border: 0px !important;
 }
 
 /* General styles */

--- a/src/js/Constants.js
+++ b/src/js/Constants.js
@@ -69,5 +69,24 @@ var Constants = {
   IMAGE_SERVICE_GET_URL : '{{protocol}}://piskel-imgstore-b.appspot.com/img/',
 
   // Code.org - hide or show all layer controls from the UI
-  ENABLE_MULTIPLE_LAYERS: false
+  ENABLE_MULTIPLE_LAYERS: false,
+
+  // Code.org - List of classes to hide in "Restricted Tools" mode
+  TOOLS_TO_RESTRICT: [
+    "icon-tool-vertical-mirror-pen",
+    "icon-tool-colorswap",
+    "icon-tool-move",
+    "icon-tool-shape-select",
+    "icon-tool-lasso-select",
+    "icon-tool-lighten",
+    "icon-tool-dithering",
+    "preview-toggle-onion-skin",
+    "icon-tool-flip",
+    "icon-tool-rotate",
+    "icon-tool-center",
+    "icon-settings-resize-white",
+    "icon-settings-export-white",
+    "drawer-content",
+    "preview-container"
+  ]
 };

--- a/src/js/Constants.js
+++ b/src/js/Constants.js
@@ -73,20 +73,20 @@ var Constants = {
 
   // Code.org - List of classes to hide in "Restricted Tools" mode
   TOOLS_TO_RESTRICT: [
-    "icon-tool-vertical-mirror-pen",
-    "icon-tool-colorswap",
-    "icon-tool-move",
-    "icon-tool-shape-select",
-    "icon-tool-lasso-select",
-    "icon-tool-lighten",
-    "icon-tool-dithering",
-    "preview-toggle-onion-skin",
-    "icon-tool-flip",
-    "icon-tool-rotate",
-    "icon-tool-center",
-    "icon-settings-resize-white",
-    "icon-settings-export-white",
-    "drawer-content",
-    "preview-container"
+    'icon-tool-vertical-mirror-pen',
+    'icon-tool-colorswap',
+    'icon-tool-move',
+    'icon-tool-shape-select',
+    'icon-tool-lasso-select',
+    'icon-tool-lighten',
+    'icon-tool-dithering',
+    'preview-toggle-onion-skin',
+    'icon-tool-flip',
+    'icon-tool-rotate',
+    'icon-tool-center',
+    'icon-settings-resize-white',
+    'icon-settings-export-white',
+    'drawer-content',
+    'preview-container'
   ]
 };

--- a/src/js/PiskelApi.js
+++ b/src/js/PiskelApi.js
@@ -82,6 +82,9 @@ var PiskelApi = (function (module) {
     // Requested spritesheet merge and load has completed
     // Arguments: none
     FRAMES_LOADED: 'FRAMES_LOADED',
+
+    // Use a restricted set of tools [Spritelab/Gamelab]
+    USE_RESTRICTED: 'USE_RESTRICTED',
   };
 
   /**
@@ -165,6 +168,15 @@ var PiskelApi = (function (module) {
   PiskelApi.prototype.addBlankFrame = function () {
     this.sendMessage_({
       type: PiskelApi.MessageType.ADD_BLANK_FRAME
+    });
+  };
+
+  /**
+   * Tell Piskel to use a restricted set of tools.
+   */
+  PiskelApi.prototype.restrictTools = function () {
+    this.sendMessage_({
+      type: PiskelApi.MessageType.USE_RESTRICTED
     });
   };
 

--- a/src/js/service/PiskelApiService.js
+++ b/src/js/service/PiskelApiService.js
@@ -265,7 +265,7 @@
   ns.PiskelApiService.prototype.restrictTools = function () {
     Constants.TOOLS_TO_RESTRICT.forEach((className) => {
       let elements = document.getElementsByClassName(className);
-      elements[0].classList.add("spritelab-hide");
+      elements[0].classList.add('spritelab-hide');
     });
   };
 })();

--- a/src/js/service/PiskelApiService.js
+++ b/src/js/service/PiskelApiService.js
@@ -127,6 +127,8 @@
       this.appendFrames(message.uri, message.frameSizeX, message.frameSizeY);
     } else if (message.type === MessageType.ADD_BLANK_FRAME) {
       this.piskelController_.addFrame();
+    } else if (message.type === MessageType.USE_RESTRICTED) {
+      this.restrictTools();
     }
   };
 
@@ -258,5 +260,12 @@
 
   ns.PiskelApiService.prototype.onAddNewFrameEvent = function () {
     this.sendMessage_({type: MessageType.ADD_NEW_FRAME_CLICKED});
+  };
+
+  ns.PiskelApiService.prototype.restrictTools = function () {
+    Constants.TOOLS_TO_RESTRICT.forEach((className) => {
+      let elements = document.getElementsByClassName(className);
+      elements[0].classList.add("spritelab-hide");
+    });
   };
 })();

--- a/src/js/service/PiskelApiService.js
+++ b/src/js/service/PiskelApiService.js
@@ -265,7 +265,9 @@
   ns.PiskelApiService.prototype.restrictTools = function () {
     Constants.TOOLS_TO_RESTRICT.forEach(function (className) {
       var elements = document.getElementsByClassName(className);
-      elements[0].classList.add('spritelab-hide');
+      Array.prototype.forEach.call(elements, function(element) {
+        element.classList.add('spritelab-hide');
+      });
     });
   };
 })();

--- a/src/js/service/PiskelApiService.js
+++ b/src/js/service/PiskelApiService.js
@@ -263,7 +263,7 @@
   };
 
   ns.PiskelApiService.prototype.restrictTools = function () {
-    Constants.TOOLS_TO_RESTRICT.forEach((className) => {
+    Constants.TOOLS_TO_RESTRICT.forEach(function (className) {
       let elements = document.getElementsByClassName(className);
       elements[0].classList.add('spritelab-hide');
     });

--- a/src/js/service/PiskelApiService.js
+++ b/src/js/service/PiskelApiService.js
@@ -263,8 +263,8 @@
   };
 
   ns.PiskelApiService.prototype.restrictTools = function () {
-    Constants.TOOLS_TO_RESTRICT.forEach((className) => {
-      let elements = document.getElementsByClassName(className);
+    Constants.TOOLS_TO_RESTRICT.forEach(function (className) {
+      var elements = document.getElementsByClassName(className);
       elements[0].classList.add('spritelab-hide');
     });
   };


### PR DESCRIPTION
![restrictedPiskel](https://user-images.githubusercontent.com/2959170/56699455-57802480-66aa-11e9-90cc-acf97bc82eee.png)

Per this spec: https://docs.google.com/document/d/1GBeHLqyTA0nHtD77LgpxIUAvB9xcGfMshb78Ucsn7jw/edit#

This PR adds a 'Restricted Mode' where only a few tools are displayed to the user. This will be used in SpriteLab. The list of tools which are hidden are placed in the constants file and I continue the established method of hiding elements using css to simplify pulling from the main branch in the future.