### PR TITLE
Change pen sizes to be 1, 4, 8, and 16 

### DIFF
--- a/src/css/widgets-size-picker.css
+++ b/src/css/widgets-size-picker.css
@@ -22,13 +22,13 @@
 .size-picker-option[data-size='1'] {
   padding: 5px;
 }
-.size-picker-option[data-size='2'] {
+.size-picker-option[data-size='4'] {
   padding: 4px;
 }
-.size-picker-option[data-size='3'] {
+.size-picker-option[data-size='8'] {
   padding: 3px;
 }
-.size-picker-option[data-size='4'] {
+.size-picker-option[data-size='16'] {
   padding: 2px;
 }
 

--- a/src/js/Constants.js
+++ b/src/js/Constants.js
@@ -1,8 +1,8 @@
 // TODO(grosbouddha): put under pskl namespace.
 var Constants = {
   DEFAULT : {
-    HEIGHT : 32,
-    WIDTH : 32,
+    HEIGHT : 256,
+    WIDTH : 256,
     FPS : 12,
     LAYER_OPACITY : 0.2
   },

--- a/src/js/widgets/SizePicker.js
+++ b/src/js/widgets/SizePicker.js
@@ -27,10 +27,10 @@
     pskl.utils.Dom.removeClass('labeled', this.container);
     pskl.utils.Dom.removeClass('selected', this.container);
     var selectedOption;
-    if (size <= 4) {
+    if (size <= 16) {
       selectedOption = this.container.querySelector('[data-size="' + size + '"]');
     } else {
-      selectedOption = this.container.querySelector('[data-size="4"]');
+      selectedOption = this.container.querySelector('[data-size="16"]');
       selectedOption.classList.add('labeled');
       selectedOption.setAttribute('real-size', size);
     }

--- a/src/templates/drawing-tools.html
+++ b/src/templates/drawing-tools.html
@@ -1,11 +1,11 @@
 <div class="sticky-section left-sticky-section" id="tool-section">
   <div class="sticky-section-wrap">
     <div class="vertical-centerer">
-      <div class="pen-size-container size-picker-container" title="Pen size<br/>from 1 to 4 pixels" rel="tooltip" data-placement="top">
+      <div class="pen-size-container size-picker-container" title="Pen size<br/>at 1, 4, 8, or 16 pixels" rel="tooltip" data-placement="top">
         <div class="pen-size-option size-picker-option" data-size="1"></div>
-        <div class="pen-size-option size-picker-option" data-size="2"></div>
-        <div class="pen-size-option size-picker-option" data-size="3"></div>
         <div class="pen-size-option size-picker-option" data-size="4"></div>
+        <div class="pen-size-option size-picker-option" data-size="8"></div>
+        <div class="pen-size-option size-picker-option" data-size="16"></div>
       </div>
       <ul id="tools-container" class="tools-wrapper">
         <!-- Drawing tools will be inserted here -->

--- a/src/templates/settings/preferences/grid.html
+++ b/src/templates/settings/preferences/grid.html
@@ -12,11 +12,11 @@
         <div class="size-picker-option"
           title="1px" rel="tooltip" data-placement="top" data-size="1"></div>
         <div class="size-picker-option"
-          title="2px" rel="tooltip" data-placement="top" data-size="2"></div>
+          title="2px" rel="tooltip" data-placement="top" data-size="4"></div>
         <div class="size-picker-option"
-          title="3px" rel="tooltip" data-placement="top" data-size="3"></div>
+          title="3px" rel="tooltip" data-placement="top" data-size="8"></div>
         <div class="size-picker-option"
-          title="4px" rel="tooltip" data-placement="top" data-size="4"></div>
+          title="4px" rel="tooltip" data-placement="top" data-size="16"></div>
       </div>
     </div>
     <div class="settings-item settings-item-grid-color">

--- a/test/casperjs/integration/settings/test-resize-default-size.js
+++ b/test/casperjs/integration/settings/test-resize-default-size.js
@@ -25,8 +25,8 @@ casper.test.begin('Test updating default size works', 14 , function(test) {
     test.assertExists('[name="default-width"]', 'Check if width input is available');
     test.assertExists('[name="default-height"]', 'Check if height input is available');
 
-    test.assertEquals(getValue('[name="default-width"]'), "32", 'Default width is 32px');
-    test.assertEquals(getValue('[name="default-height"]'), "32", 'Default height is 32px');
+    test.assertEquals(getValue('[name="default-width"]'), "256", 'Default width is 256px');
+    test.assertEquals(getValue('[name="default-height"]'), "256", 'Default height is 256px');
 
     // Update width/height
     casper.sendKeys('[name="default-width"]', "1");

--- a/test/casperjs/integration/settings/test-resize-default-size.js
+++ b/test/casperjs/integration/settings/test-resize-default-size.js
@@ -31,8 +31,8 @@ casper.test.begin('Test updating default size works', 14 , function(test) {
     // Update width/height
     casper.sendKeys('[name="default-width"]', "1");
     casper.sendKeys('[name="default-height"]', "2");
-    test.assertEquals(getValue('[name="default-width"]'), "321", 'Default width is 321px');
-    test.assertEquals(getValue('[name="default-height"]'), "322", 'Default height is 322px');
+    test.assertEquals(getValue('[name="default-width"]'), "2561", 'Default width is 2561px');
+    test.assertEquals(getValue('[name="default-height"]'), "2562", 'Default height is 2562px');
 
     casper.click('.default-size-button');
     // Changing the piskel default size should close the panel automatically
@@ -43,10 +43,10 @@ casper.test.begin('Test updating default size works', 14 , function(test) {
     test.assert(!isDrawerExpanded(), 'settings drawer is closed');
 
     test.assertEquals(evalLine('pskl.UserSettings.get("DEFAULT_SIZE").width'),
-      321, 'Piskel width is now 321 pixels');
+      2561, 'Piskel width is now 2561 pixels');
 
     test.assertEquals(evalLine('pskl.UserSettings.get("DEFAULT_SIZE").height'),
-      322, 'Piskel height is now 322 pixels');
+      2562, 'Piskel height is now 2562 pixels');
   }
 
   casper

--- a/test/casperjs/integration/settings/test-resize-input-synchronization.js
+++ b/test/casperjs/integration/settings/test-resize-input-synchronization.js
@@ -25,8 +25,8 @@ casper.test.begin('Test resize panel width/height inputs are synchronized', 28 ,
     test.assertExists('[name="resize-width"]', 'Check if width input is available');
     test.assertExists('[name="resize-height"]', 'Check if height input is available');
 
-    test.assertEquals(getValue('[name="resize-width"]'), "32", 'Resize width is 32px');
-    test.assertEquals(getValue('[name="resize-height"]'), "32", 'Resize height is 32px');
+    test.assertEquals(getValue('[name="resize-width"]'), "256", 'Resize width is 256px');
+    test.assertEquals(getValue('[name="resize-height"]'), "256", 'Resize height is 256px');
 
     // Check that the resize ratio checkbox is available and checked.
     test.assertExists('.resize-ratio-checkbox', 'Check if resize ratio checkbox is available');
@@ -36,41 +36,41 @@ casper.test.begin('Test resize panel width/height inputs are synchronized', 28 ,
 
     // Check inputs are synchronized
     casper.sendKeys('[name="resize-width"]', casper.page.event.key.Backspace);
-    test.assertEquals(getValue('[name="resize-width"]'), "3", 'Resize width is 3px');
-    test.assertEquals(getValue('[name="resize-height"]'), "3", 'Resize height is 3px');
+    test.assertEquals(getValue('[name="resize-width"]'), "25", 'Resize width is 25px');
+    test.assertEquals(getValue('[name="resize-height"]'), "25", 'Resize height is 25px');
 
     casper.sendKeys('[name="resize-width"]', "0");
-    test.assertEquals(getValue('[name="resize-width"]'), "30", 'Resize width is 30px');
-    test.assertEquals(getValue('[name="resize-height"]'), "30", 'Resize height is 30px');
+    test.assertEquals(getValue('[name="resize-width"]'), "250", 'Resize width is 250px');
+    test.assertEquals(getValue('[name="resize-height"]'), "250", 'Resize height is 250px');
 
     // Check the synchronization also works when editing height field
     casper.sendKeys('[name="resize-height"]', "0");
-    test.assertEquals(getValue('[name="resize-width"]'), "300", 'Resize width is 300px');
-    test.assertEquals(getValue('[name="resize-height"]'), "300", 'Resize height is 300px');
+    test.assertEquals(getValue('[name="resize-width"]'), "2500", 'Resize width is 2500px');
+    test.assertEquals(getValue('[name="resize-height"]'), "2500", 'Resize height is 2500px');
 
     casper.sendKeys('[name="resize-height"]', casper.page.event.key.Backspace);
-    test.assertEquals(getValue('[name="resize-width"]'), "30", 'Resize width is 30px');
-    test.assertEquals(getValue('[name="resize-height"]'), "30", 'Resize height is 30px');
+    test.assertEquals(getValue('[name="resize-width"]'), "250", 'Resize width is 250px');
+    test.assertEquals(getValue('[name="resize-height"]'), "250", 'Resize height is 250px');
 
     // Uncheck the resize ratio checkbox.
     casper.click('.resize-ratio-checkbox');
 
     // Check inputs are no longer synchronized
     casper.sendKeys('[name="resize-width"]', casper.page.event.key.Backspace);
-    test.assertEquals(getValue('[name="resize-width"]'), "3", 'Resize width is 3px');
-    test.assertEquals(getValue('[name="resize-height"]'), "30", 'Resize height is 30px');
+    test.assertEquals(getValue('[name="resize-width"]'), "25", 'Resize width is 25px');
+    test.assertEquals(getValue('[name="resize-height"]'), "250", 'Resize height is 250px');
 
     casper.sendKeys('[name="resize-width"]', "2");
-    test.assertEquals(getValue('[name="resize-width"]'), "32", 'Resize width is 32px');
-    test.assertEquals(getValue('[name="resize-height"]'), "30", 'Resize height is 30px');
+    test.assertEquals(getValue('[name="resize-width"]'), "252", 'Resize width is 252px');
+    test.assertEquals(getValue('[name="resize-height"]'), "250", 'Resize height is 250px');
 
     casper.sendKeys('[name="resize-height"]', casper.page.event.key.Backspace);
-    test.assertEquals(getValue('[name="resize-width"]'), "32", 'Resize width is 32px');
-    test.assertEquals(getValue('[name="resize-height"]'), "3", 'Resize height is 3px');
+    test.assertEquals(getValue('[name="resize-width"]'), "252", 'Resize width is 252px');
+    test.assertEquals(getValue('[name="resize-height"]'), "25", 'Resize height is 25px');
 
     casper.sendKeys('[name="resize-height"]', "2");
-    test.assertEquals(getValue('[name="resize-width"]'), "32", 'Resize width is 32px');
-    test.assertEquals(getValue('[name="resize-height"]'), "32", 'Resize height is 32px');
+    test.assertEquals(getValue('[name="resize-width"]'), "252", 'Resize width is 252px');
+    test.assertEquals(getValue('[name="resize-height"]'), "252", 'Resize height is 252px');
 
     // Check the resize ratio checkbox again
     casper.click('.resize-ratio-checkbox');

--- a/test/casperjs/integration/settings/test-resize.js
+++ b/test/casperjs/integration/settings/test-resize.js
@@ -25,8 +25,8 @@ casper.test.begin('Test resize feature works', 16 , function(test) {
     test.assertExists('[name="resize-width"]', 'Check if width input is available');
     test.assertExists('[name="resize-height"]', 'Check if height input is available');
 
-    test.assertEquals(getValue('[name="resize-width"]'), "32", 'Resize width is 32px');
-    test.assertEquals(getValue('[name="resize-height"]'), "32", 'Resize height is 32px');
+    test.assertEquals(getValue('[name="resize-width"]'), "256", 'Resize width is 256px');
+    test.assertEquals(getValue('[name="resize-height"]'), "256", 'Resize height is 256px');
 
     // Check that the resize ratio checkbox is available and checked.
     test.assertExists('.resize-ratio-checkbox', 'Check if resize ratio checkbox is available');
@@ -36,8 +36,8 @@ casper.test.begin('Test resize feature works', 16 , function(test) {
 
     // Update width/height
     casper.sendKeys('[name="resize-width"]', "0");
-    test.assertEquals(getValue('[name="resize-width"]'), "320", 'Resize width is 320px');
-    test.assertEquals(getValue('[name="resize-height"]'), "320", 'Resize height is 320px');
+    test.assertEquals(getValue('[name="resize-width"]'), "2560", 'Resize width is 2560px');
+    test.assertEquals(getValue('[name="resize-height"]'), "2560", 'Resize height is 2560px');
 
     casper.click('.resize-button');
     // Resizing the piskel should close the panel automatically
@@ -47,8 +47,8 @@ casper.test.begin('Test resize feature works', 16 , function(test) {
   function onDrawerClosed() {
     test.assert(!isDrawerExpanded(), 'settings drawer is closed');
 
-    test.assertEquals(evalLine('pskl.app.piskelController.getPiskel().getWidth()'), 320, 'Piskel width is now 320 pixels');
-    test.assertEquals(evalLine('pskl.app.piskelController.getPiskel().getHeight()'), 320, 'Piskel height is now 320 pixels');
+    test.assertEquals(evalLine('pskl.app.piskelController.getPiskel().getWidth()'), 2560, 'Piskel width is now 2560 pixels');
+    test.assertEquals(evalLine('pskl.app.piskelController.getPiskel().getHeight()'), 2560, 'Piskel height is now 2560 pixels');
   }
 
   casper

--- a/test/js/database/PiskelDatabaseTest.js
+++ b/test/js/database/PiskelDatabaseTest.js
@@ -3,6 +3,8 @@ describe('PiskelDatabase test', function () {
   // Test object.
   var piskelDatabase;
 
+  var originalTimeout;
+
   var _toSnapshot = function (session_id, name, description, date, serialized) {
     return {
       session_id: session_id,
@@ -44,6 +46,9 @@ describe('PiskelDatabase test', function () {
     var dbName = pskl.database.PiskelDatabase.DB_NAME;
     var req = window.indexedDB.deleteDatabase(dbName);
     req.onsuccess = done;
+
+    originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
   });
 
   afterEach(function () {
@@ -51,6 +56,7 @@ describe('PiskelDatabase test', function () {
     if (piskelDatabase && piskelDatabase.db) {
       piskelDatabase.db.close();
     }
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
   });
 
   it('initializes the DB and returns a promise', function (done) {


### PR DESCRIPTION
To make the play area more usable, I also increased the default canvas size to be 256. This is closer to what we use in Spritelab.

![chrome-capture (1)](https://user-images.githubusercontent.com/46464143/80560333-64a6b200-8995-11ea-9207-cd681b1d4724.gif)
