### PR TITLE
Makes MessageFormat i18n strings available in window.locales

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,6 +63,8 @@ module.exports = function(grunt) {
 
   // load all grunt tasks
   require('load-grunt-tasks')(grunt);
+  // load our custom tasks
+  grunt.loadTasks('tasks');
 
   grunt.initConfig({
     clean: {
@@ -143,12 +145,25 @@ module.exports = function(grunt) {
       }
     },
 
+    'build-i18n' : {
+      js: {
+        files: [
+          {
+            expand: true,
+            ext: '.js',
+            src: ['i18n/locales/*.json'],
+            dest: 'dest/tmp/'
+          }
+        ]
+      }
+    },
+
     concat : {
       js : {
         options : {
           separator : ';'
         },
-        src : piskelScripts,
+        src : [piskelScripts, 'dest/tmp/i18n/locales/*.js'],
         dest : 'dest/prod/js/piskel-packaged' + version + '.js'
       },
       css : {
@@ -334,7 +349,7 @@ module.exports = function(grunt) {
 
   // BUILD TASKS
   grunt.registerTask('build-index.html', ['includereplace']);
-  grunt.registerTask('merge-statics', ['concat:js', 'concat:css', 'uglify']);
+  grunt.registerTask('merge-statics', ['build-i18n:js', 'concat:js', 'concat:css', 'uglify']);
   grunt.registerTask('build',  ['clean:prod', 'sprite', 'merge-statics', 'build-index.html', 'replace:mainPartial', 'replace:css', 'copy:prod']);
   grunt.registerTask('build-dev',  ['clean:dev', 'sprite', 'build-index.html', 'copy:dev']);
   grunt.registerTask('desktop', ['clean:desktop', 'default', 'nwjs:windows']);

--- a/i18n/locales/en_us.json
+++ b/i18n/locales/en_us.json
@@ -1,0 +1,28 @@
+{
+  "penTool": "Pen tool (P)",
+  "paintBucketTool": "Paint bucket tool (B)",
+  "eraserTool": "Eraser tool (E)",
+  "strokeTool": "Stroke tool (L)",
+  "rectangleTool": "Rectangle tool (R)",
+  "filledRectangleTool": "Filled Rectangle Tool (ctrl+shift+R)",
+  "circleTool": "Circle tool (C)",
+  "filledCircleTool": "Filled Circle tool (ctrl+shift+C)",
+  "rectangleSelection": "Rectangle Selection (S)",
+  "colorPicker": "Color picker (O)",
+  "primaryLeftMouseButton": "Primary - left mouse button",
+  "secondaryRightMouseButton": "Secondary - right mouse button",
+  "penSize": "Pen size at 1, 4, 8, or 16 pixels",
+  "cropTheSprite": "Crop the sprite",
+  "primaryValue": "Value",
+  "secondaryValue": "Value",
+  "swapColors": "Swap colors (X)",
+
+  "strokeToolInstructions": "Hold shift to draw straight lines",
+  "rectangleToolInstructions": "SHIFT Keep 1 to 1 ratio",
+  "filledRectangleToolInstructions": "SHIFT Keep 1 to 1 ratio",
+  "circleToolInstructions": "SHIFT Keep 1 to 1 ratio",
+  "filledCircleToolInstructions": "SHIFT Keep 1 to 1 ratio",
+  "cropTheSpriteInstructions": "Crop to fit the content or the selection. Applies to all frames and layers!",
+
+  "loadingPiskelMessage": "Loading Piskel..."
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6409,6 +6409,22 @@
         }
       }
     },
+    "make-plural": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
+      "integrity": "sha512-xTYd4JVHpSCW+aqDof6w/MebaMVNTVYBZhbB/vi513xXdiPT92JMVCo0Jq8W2UZnzYRFeVbQiQ+I25l13JuKvA==",
+      "requires": {
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "optional": true
+        }
+      }
+    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -6485,6 +6501,26 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
+    },
+    "messageformat": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.3.0.tgz",
+      "integrity": "sha512-uTzvsv0lTeQxYI2y1NPa1lItL5VRI8Gb93Y2K2ue5gBPyrbJxfDi/EYWxh2PKv5yO42AJeeqblS9MJSh/IEk4w==",
+      "requires": {
+        "make-plural": "^4.3.0",
+        "messageformat-formatters": "^2.0.1",
+        "messageformat-parser": "^4.1.2"
+      }
+    },
+    "messageformat-formatters": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/messageformat-formatters/-/messageformat-formatters-2.0.1.tgz",
+      "integrity": "sha512-E/lQRXhtHwGuiQjI7qxkLp8AHbMD5r2217XNe/SREbBlSawe0lOqsFb7rflZJmlQFSULNLIqlcjjsCPlB3m3Mg=="
+    },
+    "messageformat-parser": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
+      "integrity": "sha512-2fU3XDCanRqeOCkn7R5zW5VQHWf+T3hH65SzuqRvjatBK7r4uyFa5mEX+k6F9Bd04LVM5G4/BHBTUJsOdW7uyg=="
     },
     "micromatch": {
       "version": "2.3.11",

--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
     "toolbar": false,
     "width": 1000,
     "height": 700
+  },
+  "dependencies": {
+    "messageformat": "^2.3.0"
   }
 }

--- a/tasks/build-i18n.js
+++ b/tasks/build-i18n.js
@@ -1,0 +1,59 @@
+// Contains Grunt tasks related to building translatable assets.
+module.exports = function(grunt) {
+  var path = require('path');
+  var MessageFormat = require('messageformat');
+
+  grunt.registerMultiTask('build-i18n', 'Compile i18n strings!', function() {
+    this.files.forEach(function(file) {
+      file.src.forEach(function(src) {
+        var locale = path.basename(src, '.json').toLowerCase();
+        var englishData = grunt.file.readJSON(src.replace(locale, 'en_us'));
+        var localeData = grunt.file.readJSON(src);
+        // Remove any strings which are empty
+        Object.keys(localeData).forEach(function(key) {
+          if (localeData[key] === '') {
+            delete localeData[key];
+          }
+        });
+        // Fill in missing strings with the English strings
+        var finalData = Object.assign(englishData, localeData);
+        try {
+          // Compile the MessageFormat JSON into usable Javascript
+          var formatted = process(locale, finalData);
+          grunt.file.write(file.dest, formatted);
+        } catch (e) {
+          var errorMsg = `Error processing localization file ${src}: ${e}`;
+          if (grunt.option('force')) {
+            grunt.log.warn(errorMsg);
+          } else {
+            throw new Error(errorMsg);
+          }
+        }
+      });
+    });
+  });
+
+  // Compiles the MessageFormat JSON into a usable Javascript object.
+  // A locale's i18n string are accessible through the `window.locales` objects.
+  // For example, to access the English 'hello': `window.locales.en_us.hello()`
+  function process(locale, json) {
+    var mf;
+    try {
+      mf = new MessageFormat(locale);
+    } catch (e) {
+      // Fallback to English if the given locale is not found
+      grunt.warn(`MessageFormat can't handle the ${locale} locale. Defaulting to en_us instead.`)
+      if (locale !== 'en_us') {
+        return process('en_us', json);
+      } else {
+        throw e;
+      }
+    }
+
+    return (
+      mf
+        .compile(json)
+        .toString('(window.locales = window.locales || {}).' + locale) + ';'
+    );
+  }
+};

--- a/tasks/build-i18n.js
+++ b/tasks/build-i18n.js
@@ -6,6 +6,7 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('build-i18n', 'Compile i18n strings!', function() {
     this.files.forEach(function(file) {
       file.src.forEach(function(src) {
+       // the locale is in the file name, i.e. i18n/locales/en_us.json. This returns the string "en_us".
         var locale = path.basename(src, '.json').toLowerCase();
         var englishData = grunt.file.readJSON(src.replace(locale, 'en_us'));
         var localeData = grunt.file.readJSON(src);


### PR DESCRIPTION
## Overview
This changes adds the `window.locales` object which provides access to translatable strings. For example `window.locales.en_us.penTool()` returns the string `"Pen tool (P)"`.

**How is `window.locales.en_us` created?**
The build target `merge-statics` in `Gruntfile.js` combines `dest/tmp/i18n/locales/en_us.js`, `.../es_es.js`, `.../de_de.js` with the main piskel js artifact. Each `.js` file contains the strings and defines `window.locales.en_us` or whatever locale they are supposed to represent.

**How are the `en_us.js`, `de_de.js`, etc files created?**
The build target `build-i18n` iterates through each `i18n/locales/*_*.json` file, compiles it with the _MessageFormat_ library, and generates each respective `dest/tmp/i18n/locales/*_*.js` file.

**Why are we using the _MessageFormat_ library?**
Currently the translatable strings don't have any dynamic content. However, if we ever want to add variable input for the translatable strings, then MessageFormat will support that (i.e. "You currently have the 'Pen Tool' selected", "You currently have the 'Brush Tool' selected"). It even has support for more advance translations like plurals and gender.

## Testing Done
* Ran `grunt serve` and verified in my web browser's Javascript console that `window.locales.en_us.penTool()` returns the expected string.
* Manually tested that `window.locales.en_us.penTool()` works in `app.js`

## Appendix
### Example MessageFormat output
Here is the example out of calling
```
   return (
      mf
        .compile(json)
        .toString('(window.locales = window.locales || {}).' + locale) + ';'
    );
```

**dest/tmp/i18n/locales/en_us.js**
```
(window.locales = window.locales || {}).en_us = {
  penTool: function(d) { return "Pen tool (P)"; },
  paintBucketTool: function(d) { return "Paint bucket tool (B)"; },
  eraserTool: function(d) { return "Eraser tool (E)"; },
  strokeTool: function(d) { return "Stroke tool (L)"; },
  rectangleTool: function(d) { return "Rectangle tool (R)"; },
  filledRectangleTool: function(d) { return "Filled Rectangle Tool (ctrl+shift+R)"; },
  circleTool: function(d) { return "Circle tool (C)"; },
  filledCircleTool: function(d) { return "Filled Circle tool (ctrl+shift+C)"; },
  rectangleSelection: function(d) { return "Rectangle Selection (S)"; },
  colorPicker: function(d) { return "Color picker (O)"; },
  primaryLeftMouseButton: function(d) { return "Primary - left mouse button"; },
  secondaryRightMouseButton: function(d) { return "Secondary - right mouse button"; },
  penSize: function(d) { return "Pen size at 1, 4, 8, or 16 pixels"; },
  cropTheSprite: function(d) { return "Crop the sprite"; },
  primaryValue: function(d) { return "Value"; },
  secondaryValue: function(d) { return "Value"; },
  swapColors: function(d) { return "Swap colors (X)"; },
  strokeToolInstructions: function(d) { return "Hold shift to draw straight lines"; },
  rectangleToolInstructions: function(d) { return "SHIFT Keep 1 to 1 ratio"; },
  filledRectangleToolInstructions: function(d) { return "SHIFT Keep 1 to 1 ratio"; },
  circleToolInstructions: function(d) { return "SHIFT Keep 1 to 1 ratio"; },
  filledCircleToolInstructions: function(d) { return "SHIFT Keep 1 to 1 ratio"; },
  cropTheSpriteInstructions: function(d) { return "Crop to fit the content or the selection. Applies to all frames and layers!"; },
  loadingPiskelMessage: function(d) { return "Loading Piskel..."; }
};
```