### PR TITLE
[Salvador Villalon] lowering lines length for eslint

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -18,19 +18,20 @@
         * Note that en_US.json should contain all available strings because this is the locale other
         * languages will fallback to if a translation from English doesn't exist.
         *
-        * The strings that we will be used depend on the window.piskel_locale. window.piskel_locale is the 4 letter locale
-        * code defined by users of the Piskel library so they can optionally load non-English strings
-        * into the Piskel UI. For example "en_us" or "es_es"
+        * The strings that we will be used depend on the window.piskel_locale. window.piskel_locale is
+        * the 4 letter locale code defined by users of the Piskel library so they can optionally
+        * load non-English strings into the Piskel UI. For example "en_us" or "es_es"
         *
-        * window.piskel_locales will contains all strings available, then we will use window.piskel_locale to select the language
-        * we want strings to be in. All of this is happening here: var i18n = window.piskel_locales[window.piskel_locale];
+        * window.piskel_locales will contains all strings available, then we will use window.piskel_locale
+        * to select the language we want strings to be in. All of this is happening here:
+        * var i18n = window.piskel_locales[window.piskel_locale];
         * In the case that window.piskel_locale is undefined, we set the strings to English by default
         *
         * Example Usage tools/drawing/SimplePen.js:
         * this.helpText = i18n.simplePenDrawingTool()
         * Now when the user hovers over the Pen tool, they will see the translation based on the locale
-        * The i18n object is passed in the Controllers that have text to translate. For example ToolController takes in the
-        * i18n object so that it can be used in all the Tools like Stroke and Pen Tool
+        * The i18n object is passed in the Controllers that have text to translate. For example
+        * ToolController takes in the i18n object so that it can be used in all the Tools like Stroke and Pen Tool
         *
         * To see how each key becomes a function look at the tasks/build-i18n.js file where we use the MessageFormat API
       */

--- a/src/js/controller/preview/PreviewController.js
+++ b/src/js/controller/preview/PreviewController.js
@@ -57,7 +57,10 @@
 
     var registerShortcut = pskl.app.shortcutService.registerShortcut.bind(pskl.app.shortcutService);
     registerShortcut(this.onionSkinShortcut, this.toggleOnionSkin_.bind(this));
-    var onionSkinTooltip = pskl.utils.TooltipFormatter.format(this.i18n.onionSkinTogglePreviewTool(), this.onionSkinShortcut);
+    var onionSkinTooltip = pskl.utils.TooltipFormatter.format(
+      this.i18n.onionSkinTogglePreviewTool(),
+      this.onionSkinShortcut
+    );
     this.toggleOnionSkinButton.setAttribute('title', onionSkinTooltip);
 
     for (var size in this.previewSizes) {

--- a/src/js/controller/settings/exportimage/GifExportController.js
+++ b/src/js/controller/settings/exportimage/GifExportController.js
@@ -252,7 +252,8 @@
     var html = '';
     html += this.createGifExportDownloadSection(i18n);
     html += this.createGifExportUploadSection(i18n);
-    html += '<div class=\'gif-upload\'><div class=\'gif-export-preview\'></div><div class=\'gif-upload-status\'></div></div>';
+    html += '<div class=\'gif-upload\'><div class=\'gif-export-preview\'></div>' +
+      '<div class=\'gif-upload-status\'></div></div>';
     $('#gif-export-actions-section').html(html);
   };
 })();

--- a/src/js/tools/drawing/selection/BaseSelect.js
+++ b/src/js/tools/drawing/selection/BaseSelect.js
@@ -26,7 +26,9 @@
       {key : 'shift', description : i18n.baseSelectDrawingSelectionToolDescriptorMoveTheContent()}
     ];
     if (!Constants.ENABLE_MULTIPLE_LAYERS) {
-      this.tooltipDescriptors[0] = {description : i18n.baseSelectDrawingSelectionToolDescriptorDragTheSelectionMaySwitchToOtherFrames()};
+      this.tooltipDescriptors[0] = {
+        description: i18n.baseSelectDrawingSelectionToolDescriptorDragTheSelectionMaySwitchToOtherFrames()
+      };
     }
     $.subscribe(Events.SELECTION_DISMISSED, this.onSelectionDismissed_.bind(this));
   };

--- a/src/js/widgets/Tabs.js
+++ b/src/js/widgets/Tabs.js
@@ -38,7 +38,11 @@
     }
 
     this.tabContentlEl.innerHTML = pskl.utils.Template.get(this.tabs[tabId].template);
-    this.currentController = new this.tabs[tabId].controller(pskl.app.piskelController, this.parentController, this.i18n);
+    this.currentController = new this.tabs[tabId].controller(
+      pskl.app.piskelController,
+      this.parentController,
+      this.i18n
+    );
     this.currentController.init();
     this.currentTab = tabId;
     pskl.UserSettings.set(this.settingsName, tabId);


### PR DESCRIPTION
When I was trying to do npm version patch, it did an eslint check and gave an error saying that some lines of code where too long. I went back to fix this

```
salvillalon45@DESKTOP-OGUBHNT:~/projects/test1/piskel$ npm version patch

> @code-dot-org/piskel@0.13.0 preversion /home/salvillalon45/projects/test1/piskel
> grunt test build

(node:1248) [DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.
Running "eslint:files" (eslint) task

/home/salvillalon45/projects/test1/piskel/src/js/app.js
  21:1  error  Line 21 exceeds the maximum line length of 120  max-len
  25:1  error  Line 25 exceeds the maximum line length of 120  max-len
  26:1  error  Line 26 exceeds the maximum line length of 120  max-len
  32:1  error  Line 32 exceeds the maximum line length of 120  max-len

/home/salvillalon45/projects/test1/piskel/src/js/controller/preview/PreviewController.js
  60:1  error  Line 60 exceeds the maximum line length of 120  max-len

/home/salvillalon45/projects/test1/piskel/src/js/controller/settings/exportimage/GifExportController.js
  255:1  error  Line 255 exceeds the maximum line length of 120  max-len

/home/salvillalon45/projects/test1/piskel/src/js/tools/drawing/selection/BaseSelect.js
  29:1  error  Line 29 exceeds the maximum line length of 120  max-len

/home/salvillalon45/projects/test1/piskel/src/js/widgets/Tabs.js
  41:1  error  Line 41 exceeds the maximum line length of 120  max-len

✖ 8 problems (8 errors, 0 warnings)
```